### PR TITLE
Fixed invalid path

### DIFF
--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -22,7 +22,7 @@ namespace Impostor.Server.Plugins
             var pluginPaths = new List<string>(config.Paths);
             var libraryPaths = new List<string>(config.LibraryPaths);
 
-            var rootFolder = Assembly.GetEntryAssembly()?.Location;
+            var rootFolder = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location);
             if (rootFolder != null)
             {
                 pluginPaths.Add(Path.Combine(rootFolder, "plugins"));


### PR DESCRIPTION
``Assembly.GetEntryAssembly()?.Location`` gives the path + Name.dll
``Path.Combine(rootFolder, "plugins")`` would lead to ``root\Assembly.dll\Plugins`` but we actually want ``root\plugins\``