### PR TITLE
Player Reported Body Crash Fix

### DIFF
--- a/src/Impostor.Api/Events/Game/Player/IPlayerReportedBodyEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerReportedBodyEvent.cs
@@ -1,0 +1,12 @@
+using Impostor.Api.Net.Inner.Objects;
+
+namespace Impostor.Api.Events.Player
+{
+    public interface IPlayerReportedBodyEvent : IPlayerEvent
+    {
+        /// <summary>
+        ///     Gets the player who's body got reported.
+        /// </summary>
+        IInnerPlayerControl Victim { get; }
+    }
+}

--- a/src/Impostor.Api/Events/Game/Player/IPlayerReportedBodyEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerReportedBodyEvent.cs
@@ -6,6 +6,7 @@ namespace Impostor.Api.Events.Player
     {
         /// <summary>
         ///     Gets the player who's body got reported.
+        ///     Body can be null if the report happens too quickly.
         /// </summary>
         IInnerPlayerControl Body { get; }
     }

--- a/src/Impostor.Api/Events/Game/Player/IPlayerReportedBodyEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerReportedBodyEvent.cs
@@ -7,6 +7,6 @@ namespace Impostor.Api.Events.Player
         /// <summary>
         ///     Gets the player who's body got reported.
         /// </summary>
-        IInnerPlayerControl Victim { get; }
+        IInnerPlayerControl Body { get; }
     }
 }

--- a/src/Impostor.Server/Events/Game/Player/PlayerReportedBodyEvent.cs
+++ b/src/Impostor.Server/Events/Game/Player/PlayerReportedBodyEvent.cs
@@ -7,12 +7,12 @@ namespace Impostor.Server.Events.Player
 {
     public class PlayerReportedBodyEvent : IPlayerReportedBodyEvent
     {
-        public PlayerReportedBodyEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, IInnerPlayerControl victim)
+        public PlayerReportedBodyEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, IInnerPlayerControl body)
         {
             Game = game;
             ClientPlayer = clientPlayer;
             PlayerControl = playerControl;
-            Victim = victim;
+            Body = body;
         }
 
         public IGame Game { get; }
@@ -21,6 +21,6 @@ namespace Impostor.Server.Events.Player
 
         public IInnerPlayerControl PlayerControl { get; }
 
-        public IInnerPlayerControl Victim { get; }
+        public IInnerPlayerControl Body { get; }
     }
 }

--- a/src/Impostor.Server/Events/Game/Player/PlayerReportedBodyEvent.cs
+++ b/src/Impostor.Server/Events/Game/Player/PlayerReportedBodyEvent.cs
@@ -1,0 +1,26 @@
+using Impostor.Api.Events.Player;
+using Impostor.Api.Games;
+using Impostor.Api.Net;
+using Impostor.Api.Net.Inner.Objects;
+
+namespace Impostor.Server.Events.Player
+{
+    public class PlayerReportedBodyEvent : IPlayerReportedBodyEvent
+    {
+        public PlayerReportedBodyEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, IInnerPlayerControl victim)
+        {
+            Game = game;
+            ClientPlayer = clientPlayer;
+            PlayerControl = playerControl;
+            Victim = victim;
+        }
+
+        public IGame Game { get; }
+
+        public IClientPlayer ClientPlayer { get; }
+
+        public IInnerPlayerControl PlayerControl { get; }
+
+        public IInnerPlayerControl Victim { get; }
+    }
+}

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -249,7 +249,8 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     var deadBodyPlayerId = reader.ReadByte();
-                    await _eventManager.CallAsync(new PlayerReportedBodyEvent(_game, sender, this, _game.GetClientPlayer(deadBodyPlayerId).Character));
+                    var clientPlayer = _game.GetClientPlayer(deadBodyPlayerId);
+                    await _eventManager.CallAsync(new PlayerReportedBodyEvent(_game, sender, this, clientPlayer?.Character));
 
                     break;
                 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -249,11 +249,7 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     var deadBodyPlayerId = reader.ReadByte();
-                    foreach (var player in _game.Players.Where(p => p.Client.Id == deadBodyPlayerId))
-                    {
-                        await _eventManager.CallAsync(new PlayerReportedBodyEvent(_game, sender, this, player.Character));
-                        break;
-                    }
+                    await _eventManager.CallAsync(new PlayerReportedBodyEvent(_game, sender, this, _game.GetClientPlayer(deadBodyPlayerId).Character));
 
                     break;
                 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Impostor.Api;
 using Impostor.Api.Events.Managers;
@@ -248,6 +249,12 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     var deadBodyPlayerId = reader.ReadByte();
+                    foreach (var player in _game.Players.Where(p => p.Client.Id == deadBodyPlayerId))
+                    {
+                        await _eventManager.CallAsync(new PlayerReportedBodyEvent(_game, sender, this, player.Character));
+                        break;
+                    }
+
                     break;
                 }
 


### PR DESCRIPTION
There's a nullref exception thrown if a player reports a body the same second that a victim is killed.

I've added a nullptr check and updated the comments for the interface accordingly.