### PR TITLE
Inner player control API functionality additions

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
@@ -3,7 +3,7 @@ using Impostor.Api.Innersloth.Customization;
 
 namespace Impostor.Api.Net.Inner.Objects
 {
-    public interface IInnerPlayerControl
+    public interface IInnerPlayerControl : IInnerNetObject
     {
         /// <summary>
         ///     Gets the <see cref="IInnerPlayerInfo"/> of the <see cref="IInnerPlayerControl"/>.
@@ -80,8 +80,9 @@ namespace Impostor.Api.Net.Inner.Objects
         ///     Visible to only the current.
         /// </summary>
         /// <param name="text">The message to send.</param>
+        /// <param name="player">The player that should receive this chat message.</param>
         /// <returns>Task that must be awaited.</returns>
-        ValueTask SendChatToPlayerAsync(string text);
+        ValueTask SendChatToPlayerAsync(string text, IInnerPlayerControl player);
 
         /// <summary>
         ///     Sets the current to infected (impostor) <see cref="IInnerPlayerControl"/>.

--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Impostor.Api.Innersloth.Customization;
 
 namespace Impostor.Api.Net.Inner.Objects
@@ -74,5 +74,27 @@ namespace Impostor.Api.Net.Inner.Objects
         /// <param name="text">The message to send.</param>
         /// <returns>Task that must be awaited.</returns>
         ValueTask SendChatAsync(string text);
+
+        /// <summary>
+        ///     Send a chat message as the current <see cref="IInnerPlayerControl"/>.
+        ///     Visible to only the current.
+        /// </summary>
+        /// <param name="text">The message to send.</param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SendChatToPlayerAsync(string text);
+
+        /// <summary>
+        ///     Sets the current to infected (impostor) <see cref="IInnerPlayerControl"/>.
+        ///     Visible to all players.
+        /// </summary>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SetInfectedAsync();
+
+        /// <summary>
+        ///     Sets the current to be murdered <see cref="IInnerPlayerControl"/>.
+        ///     Visible to all players.
+        /// </summary>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SetMurderedAsync();
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Impostor.Api.Innersloth.Customization;
 using Impostor.Api.Net.Inner.Objects;
 
@@ -77,6 +77,31 @@ namespace Impostor.Server.Net.Inner.Objects
         {
             using var writer = _game.StartRpc(NetId, RpcCalls.SendChat);
             writer.Write(text);
+            await _game.FinishRpcAsync(writer);
+        }
+
+        public async ValueTask SendChatToPlayerAsync(string text)
+        {
+            using var writer = _game.StartRpc(NetId, RpcCalls.SendChat);
+            writer.Write(text);
+
+            writer.EndMessage();
+            writer.EndMessage();
+
+            await _game.SendToAsync(writer, OwnerId);
+        }
+
+        public async ValueTask SetMurderedAsync()
+        {
+            var writer = _game.StartRpc(NetId, RpcCalls.MurderPlayer);
+            writer.Write((byte)NetId);
+            await _game.FinishRpcAsync(writer);
+        }
+
+        public async ValueTask SetInfectedAsync()
+        {
+            var writer = _game.StartRpc(NetId, RpcCalls.SetInfected);
+            writer.Write((byte)NetId);
             await _game.FinishRpcAsync(writer);
         }
     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Impostor.Api.Innersloth.Customization;
+using Impostor.Api.Net;
 using Impostor.Api.Net.Inner.Objects;
 
 namespace Impostor.Server.Net.Inner.Objects
@@ -80,15 +81,11 @@ namespace Impostor.Server.Net.Inner.Objects
             await _game.FinishRpcAsync(writer);
         }
 
-        public async ValueTask SendChatToPlayerAsync(string text)
+        public async ValueTask SendChatToPlayerAsync(string text, IInnerPlayerControl player)
         {
             using var writer = _game.StartRpc(NetId, RpcCalls.SendChat);
             writer.Write(text);
-
-            writer.EndMessage();
-            writer.EndMessage();
-
-            await _game.SendToAsync(writer, OwnerId);
+            await _game.FinishRpcAsync(writer, player.OwnerId);
         }
 
         public async ValueTask SetMurderedAsync()

--- a/src/Impostor.Server/Net/State/Game.Outgoing.cs
+++ b/src/Impostor.Server/Net/State/Game.Outgoing.cs
@@ -60,12 +60,14 @@ namespace Impostor.Server.Net.State
             return writer;
         }
 
-        internal ValueTask FinishRpcAsync(IMessageWriter writer)
+        internal ValueTask FinishRpcAsync(IMessageWriter writer, int? targetClientId = null)
         {
             writer.EndMessage();
             writer.EndMessage();
 
-            return SendToAllAsync(writer);
+            return targetClientId.HasValue
+                ? SendToAsync(writer, targetClientId.Value)
+                : SendToAllAsync(writer);
         }
 
         private void WriteRemovePlayerMessage(IMessageWriter message, bool clear, int playerId, DisconnectReason reason)


### PR DESCRIPTION
### Description
Adds the ability to set murdered, set infected, and send a chat message only to the current player that owns the InnerPlayerControl.