### PR TITLE
Fixed IsCancelled on interface events

### DIFF
--- a/src/Impostor.Server/Events/EventManager.cs
+++ b/src/Impostor.Server/Events/EventManager.cs
@@ -146,7 +146,7 @@ namespace Impostor.Server.Events
 
                 foreach (var eventHandler in events)
                 {
-                    if (eventHandler.EventType != typeof(TEvent))
+                    if (eventHandler.EventType != typeof(TEvent) && !interfaces.Contains(eventHandler.EventType))
                     {
                         continue;
                     }

--- a/src/Impostor.Server/Events/Register/RegisteredEventListener.cs
+++ b/src/Impostor.Server/Events/Register/RegisteredEventListener.cs
@@ -12,6 +12,8 @@ namespace Impostor.Server.Events.Register
 {
     internal class RegisteredEventListener : IRegisteredEventListener
     {
+        private static readonly PropertyInfo IsCancelledProperty = typeof(IEventCancelable).GetProperty(nameof(IEventCancelable.IsCancelled))!;
+
         private static readonly ConcurrentDictionary<Type, RegisteredEventListener[]> Instances = new ConcurrentDictionary<Type, RegisteredEventListener[]>();
         private readonly Func<object, object, IServiceProvider, ValueTask> _invoker;
         private readonly Type _eventListenerType;
@@ -86,7 +88,7 @@ namespace Impostor.Server.Events.Register
                 {
                     invoke = Expression.Block(
                         Expression.IfThenElse(
-                            Expression.Property(@event, nameof(IEventCancelable.IsCancelled)),
+                            Expression.Property(@event, IsCancelledProperty),
                             Expression.Return(returnTarget, Expression.Default(typeof(ValueTask))),
                             Expression.Block(
                                 invoke,
@@ -106,7 +108,7 @@ namespace Impostor.Server.Events.Register
                 {
                     invoke = Expression.Block(
                         Expression.IfThenElse(
-                            Expression.Property(@event, nameof(IEventCancelable.IsCancelled)),
+                            Expression.Property(@event, IsCancelledProperty),
                             Expression.Return(returnTarget, Expression.Default(typeof(ValueTask))),
                             Expression.Return(returnTarget, invoke)),
                         Expression.Label(returnTarget, Expression.Default(typeof(ValueTask))));

--- a/src/Impostor.Tests/Events/EventManagerTests.cs
+++ b/src/Impostor.Tests/Events/EventManagerTests.cs
@@ -118,7 +118,12 @@ namespace Impostor.Tests.Events
             Temporary
         }
 
-        public class SetValueEvent : IEventCancelable
+        public interface ISetValueEvent : IEventCancelable
+        {
+            int Value { get; }
+        }
+
+        public class SetValueEvent : ISetValueEvent
         {
             public SetValueEvent(int value)
             {
@@ -133,7 +138,7 @@ namespace Impostor.Tests.Events
         private class CancelAtHighEventListener : IEventListener
         {
             [EventListener(Priority = EventPriority.High)]
-            public void OnSetCalled(SetValueEvent e) => e.IsCancelled = true;
+            public void OnSetCalled(ISetValueEvent e) => e.IsCancelled = true;
         }
 
         private class EventListener : IEventListener
@@ -141,7 +146,7 @@ namespace Impostor.Tests.Events
             public int Value { get; private set; }
 
             [EventListener]
-            public void OnSetCalled(SetValueEvent e) => Value = e.Value;
+            public void OnSetCalled(ISetValueEvent e) => Value = e.Value;
         }
 
         private class PriorityEventListener : IEventListener
@@ -149,22 +154,22 @@ namespace Impostor.Tests.Events
             public List<EventPriority> Priorities { get; } = new List<EventPriority>();
 
             [EventListener(EventPriority.Lowest)]
-            public void OnLowest(SetValueEvent e) => Priorities.Add(EventPriority.Lowest);
+            public void OnLowest(ISetValueEvent e) => Priorities.Add(EventPriority.Lowest);
 
             [EventListener(EventPriority.Low)]
-            public void OnLow(SetValueEvent e) => Priorities.Add(EventPriority.Low);
+            public void OnLow(ISetValueEvent e) => Priorities.Add(EventPriority.Low);
 
             [EventListener]
-            public void OnNormal(SetValueEvent e) => Priorities.Add(EventPriority.Normal);
+            public void OnNormal(ISetValueEvent e) => Priorities.Add(EventPriority.Normal);
 
             [EventListener(EventPriority.High)]
-            public void OnHigh(SetValueEvent e) => Priorities.Add(EventPriority.High);
+            public void OnHigh(ISetValueEvent e) => Priorities.Add(EventPriority.High);
 
             [EventListener(EventPriority.Highest)]
-            public void OnHighest(SetValueEvent e) => Priorities.Add(EventPriority.Highest);
+            public void OnHighest(ISetValueEvent e) => Priorities.Add(EventPriority.Highest);
 
             [EventListener(EventPriority.Monitor)]
-            public void OnMonitor(SetValueEvent e) => Priorities.Add(EventPriority.Monitor);
+            public void OnMonitor(ISetValueEvent e) => Priorities.Add(EventPriority.Monitor);
         }
     }
 }


### PR DESCRIPTION
### Description
Fixed exception when the an interface type extends `IEventCancelable` and is being used in `EventManager.CallAsync<T>`.