### PR TITLE
PlayerSetStartCounterEvent

### DIFF
--- a/src/Impostor.Api/Events/Game/Player/IPlayerSetStartCounterEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerSetStartCounterEvent.cs
@@ -1,0 +1,10 @@
+namespace Impostor.Api.Events.Player
+{
+    public interface IPlayerSetStartCounterEvent : IPlayerEvent
+    {
+        /// <summary>
+        ///     Gets the current time of the start counter.
+        /// </summary>
+        byte Value { get; }
+    }
+}

--- a/src/Impostor.Server/Events/Game/Player/PlayerSetStartCounterEvent.cs
+++ b/src/Impostor.Server/Events/Game/Player/PlayerSetStartCounterEvent.cs
@@ -1,0 +1,26 @@
+using Impostor.Api.Events.Player;
+using Impostor.Api.Games;
+using Impostor.Api.Net;
+using Impostor.Api.Net.Inner.Objects;
+
+namespace Impostor.Server.Events.Game.Player
+{
+    public class PlayerSetStartCounterEvent : IPlayerSetStartCounterEvent
+    {
+        public PlayerSetStartCounterEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, byte value)
+        {
+            Game = game;
+            ClientPlayer = clientPlayer;
+            PlayerControl = playerControl;
+            Value = value;
+        }
+
+        public byte Value { get; }
+
+        public IClientPlayer ClientPlayer { get; }
+
+        public IInnerPlayerControl PlayerControl { get; }
+
+        public IGame Game { get; }
+    }
+}

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -6,6 +6,7 @@ using Impostor.Api.Events.Managers;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Messages;
+using Impostor.Server.Events.Game.Player;
 using Impostor.Server.Events.Player;
 using Impostor.Server.Net.Inner.Objects.Components;
 using Impostor.Server.Net.State;
@@ -397,6 +398,12 @@ namespace Impostor.Server.Net.Inner.Objects
 
                     // Is either start countdown or byte.MaxValue
                     var secondsLeft = reader.ReadByte();
+
+                    if (secondsLeft < byte.MaxValue)
+                    {
+                        await _eventManager.CallAsync(new PlayerSetStartCounterEvent(_game, sender, this, secondsLeft));
+                    }
+
                     break;
                 }
 


### PR DESCRIPTION
### Description
Adds a player set start counter-event. 
It's called when the start counter gets updated after pressing the "start" button in a lobby.