### PR TITLE
Update pull request template to use github "closes" keyword

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,8 @@ If your pull request closes any issues, add them below with the `closes` keyword
 
 Example: closes #101
 
+See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+
 -->
 
 ### Closes issues

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,14 @@
 ### Description
 
 
+<!-- 
+
+If your pull request closes any issues, add them below with the `closes` keyword before them 
+
+Example: closes #101
+
+-->
 
 ### Closes issues
 
-- #
+- closes #


### PR DESCRIPTION
Currently, if a pr author adds an issue to the closed issues section of the pr, they aren't automatically closed. (Example: #91 and #112).

This pr modifies the pull request template to let authors know how github's keyword system works.

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword