### PR TITLE
Possible implementation of configurable anticheat

### DIFF
--- a/docs/Server-configuration.md
+++ b/docs/Server-configuration.md
@@ -17,7 +17,8 @@ Some information about all the possible configurations. Click [here](https://git
 
 | Key | Default | Value |
 |-|-|-|
-| **BanIpFromGame** | `true` | When a player is caught hacking, he will be kicked from the server. If this value is set to `true`, the player will also be banned and can not rejoin that specific game. |
+| **Enabled** | `true` | If enabled, players sending packets they shouldn't send will be kicked from the server. |
+| **BanIpFromGame** | `true` | Whether or not cheating players should be banned. If this is set to false, they will only be kicked. |
 
 ### ServerRedirector
 

--- a/src/Impostor.Api/Exceptions/ImpostorCheatException.cs
+++ b/src/Impostor.Api/Exceptions/ImpostorCheatException.cs
@@ -20,5 +20,23 @@ namespace Impostor.Api
         public ImpostorCheatException(string? message, Exception? innerException) : base(message, innerException)
         {
         }
+
+        public static void ThrowIfEnabled(ImpostorCheatException exception)
+        {
+            // if (antiCheatConfig.Enabled) throw exception;
+            
+            // TODO: Figure out how to access the anticheat config without breaking dependency injection guidelines
+            
+            throw new NotImplementedException();
+        }
+        
+        public static void ThrowIfEnabled(SerializationInfo info, StreamingContext context)
+            => ThrowIfEnabled(new ImpostorCheatException(info, context));
+        
+        public static void ThrowIfEnabled(string? message)
+            => ThrowIfEnabled(new ImpostorCheatException(message));
+        
+        public static void ThrowIfEnabled(string? message, Exception? innerException)
+            => ThrowIfEnabled(new ImpostorCheatException(message, innerException));
     }
 }

--- a/src/Impostor.Server/Config/AntiCheatConfig.cs
+++ b/src/Impostor.Server/Config/AntiCheatConfig.cs
@@ -4,6 +4,8 @@
     {
         public const string Section = "AntiCheat";
 
+        public bool Enabled { get; set; } = true;
+        
         public bool BanIpFromGame { get; set; } = true;
     }
 }

--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -175,12 +175,15 @@ namespace Impostor.Server.Net
                     }
                     catch (ImpostorCheatException e)
                     {
-                        if (_antiCheatConfig.BanIpFromGame)
+                        if (_antiCheatConfig.Enabled)
                         {
-                            Player.Game.BanIp(Connection.EndPoint.Address);
-                        }
+                            if (_antiCheatConfig.BanIpFromGame)
+                            {
+                                Player.Game.BanIp(Connection.EndPoint.Address);
+                            }
 
-                        await DisconnectAsync(DisconnectReason.Hacking, e.Message);
+                            await DisconnectAsync(DisconnectReason.Hacking, e.Message);
+                        }
                     }
 
                     break;

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
@@ -58,17 +58,17 @@ namespace Impostor.Server.Net.Inner.Objects.Components
             {
                 if (!sender.IsOwner(this))
                 {
-                    throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SnapTo)} to an unowned {nameof(InnerPlayerControl)}");
+                    ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SnapTo)} to an unowned {nameof(InnerPlayerControl)}");
                 }
 
                 if (target != null)
                 {
-                    throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SnapTo)} to a specific player instead of broadcast");
+                    ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SnapTo)} to a specific player instead of broadcast");
                 }
 
                 if (!sender.Character.PlayerInfo.IsImpostor)
                 {
-                    throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SnapTo)} as crewmate");
+                    ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SnapTo)} as crewmate");
                 }
 
                 SnapTo(ReadVector2(reader), reader.ReadUInt16());
@@ -114,12 +114,12 @@ namespace Impostor.Server.Net.Inner.Objects.Components
             {
                 if (!sender.IsOwner(this))
                 {
-                    throw new ImpostorCheatException($"Client attempted to send unowned {nameof(InnerCustomNetworkTransform)} data");
+                    ImpostorCheatException.ThrowIfEnabled($"Client attempted to send unowned {nameof(InnerCustomNetworkTransform)} data");
                 }
 
                 if (target != null)
                 {
-                    throw new ImpostorCheatException($"Client attempted to send {nameof(InnerCustomNetworkTransform)} data to a specific player, must be broadcast");
+                    ImpostorCheatException.ThrowIfEnabled($"Client attempted to send {nameof(InnerCustomNetworkTransform)} data to a specific player, must be broadcast");
                 }
 
                 if (!SidGreaterThan(sequenceId, _lastSequenceId))

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -29,17 +29,17 @@ namespace Impostor.Server.Net.Inner.Objects.Components
 
             if (!sender.IsOwner(this))
             {
-                throw new ImpostorCheatException($"Client sent {call} to an unowned {nameof(InnerPlayerControl)}");
+                ImpostorCheatException.ThrowIfEnabled($"Client sent {call} to an unowned {nameof(InnerPlayerControl)}");
             }
 
             if (target != null)
             {
-                throw new ImpostorCheatException($"Client sent {call} to a specific player instead of broadcast");
+                ImpostorCheatException.ThrowIfEnabled($"Client sent {call} to a specific player instead of broadcast");
             }
 
             if (!sender.Character.PlayerInfo.IsImpostor)
             {
-                throw new ImpostorCheatException($"Client sent {call} as crewmate");
+                ImpostorCheatException.ThrowIfEnabled($"Client sent {call} as crewmate");
             }
 
             var ventId = reader.ReadPackedUInt32();

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerVoteBanSystem.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerVoteBanSystem.cs
@@ -32,12 +32,12 @@ namespace Impostor.Server.Net.Inner.Objects.Components
             var clientId = reader.ReadInt32();
             if (clientId != sender.Client.Id)
             {
-                throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.AddVote)} as other client");
+                ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.AddVote)} as other client");
             }
 
             if (target != null)
             {
-                throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CastVote)} to wrong destinition, must be broadcast");
+                ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CastVote)} to wrong destinition, must be broadcast");
             }
 
             var targetClientId = reader.ReadInt32();
@@ -56,7 +56,7 @@ namespace Impostor.Server.Net.Inner.Objects.Components
         {
             if (!sender.IsHost)
             {
-                throw new ImpostorCheatException($"Client attempted to send data for {nameof(InnerShipStatus)} as non-host");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send data for {nameof(InnerShipStatus)} as non-host");
             }
 
             var votes = _votes;

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -52,12 +52,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetTasks)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetTasks)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetTasks)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetTasks)} to a specific player instead of broadcast");
                     }
 
                     var playerId = reader.ReadByte();
@@ -71,12 +71,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetTasks)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetTasks)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetTasks)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetTasks)} to a specific player instead of broadcast");
                     }
 
                     while (reader.Position < reader.Length)
@@ -122,7 +122,7 @@ namespace Impostor.Server.Net.Inner.Objects
         {
             if (!sender.IsHost)
             {
-                throw new ImpostorCheatException($"Client attempted to send data for {nameof(InnerGameData)} as non-host");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send data for {nameof(InnerGameData)} as non-host");
             }
 
             if (initialState)

--- a/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
@@ -54,12 +54,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Close)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.Close)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Close)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.Close)} to a specific player instead of broadcast");
                     }
 
                     break;
@@ -69,12 +69,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.VotingComplete)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.VotingComplete)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.VotingComplete)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.VotingComplete)} to a specific player instead of broadcast");
                     }
 
                     var states = reader.ReadBytesAndSize();
@@ -101,19 +101,19 @@ namespace Impostor.Server.Net.Inner.Objects
                     var srcPlayerId = reader.ReadByte();
                     if (srcPlayerId != sender.Character.PlayerId)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CastVote)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CastVote)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     // Host broadcasts vote to others.
                     if (sender.IsHost && target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CastVote)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CastVote)} to a specific player instead of broadcast");
                     }
 
                     // Player sends vote to host.
                     if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CastVote)} to wrong destinition, must be host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CastVote)} to wrong destinition, must be host");
                     }
 
                     var targetPlayerId = reader.ReadByte();
@@ -137,12 +137,12 @@ namespace Impostor.Server.Net.Inner.Objects
         {
             if (!sender.IsHost)
             {
-                throw new ImpostorCheatException($"Client attempted to send data for {nameof(InnerMeetingHud)} as non-host");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send data for {nameof(InnerMeetingHud)} as non-host");
             }
 
             if (target != null)
             {
-                throw new ImpostorCheatException($"Client attempted to send {nameof(InnerMeetingHud)} data to a specific player, must be broadcast");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send {nameof(InnerMeetingHud)} data to a specific player, must be broadcast");
             }
 
             if (initialState)

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -55,12 +55,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.PlayAnimation)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.PlayAnimation)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.PlayAnimation)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.PlayAnimation)} to a specific player instead of broadcast");
                     }
 
                     var animation = reader.ReadByte();
@@ -72,12 +72,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CompleteTask)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CompleteTask)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CompleteTask)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CompleteTask)} to a specific player instead of broadcast");
                     }
 
                     var index = reader.ReadPackedUInt32();
@@ -89,7 +89,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SyncSettings)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SyncSettings)} but was not a host");
                     }
 
                     _game.Options.Deserialize(reader.ReadBytesAndSize());
@@ -101,7 +101,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetInfected)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetInfected)} but was not a host");
                     }
 
                     var length = reader.ReadPackedInt32();
@@ -129,12 +129,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Exiled)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.Exiled)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Exiled)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.Exiled)} to a specific player instead of broadcast");
                     }
 
                     // TODO: Not hit?
@@ -149,7 +149,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CheckName)} to the wrong player");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CheckName)} to the wrong player");
                     }
 
                     var name = reader.ReadString();
@@ -161,12 +161,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetName)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetName)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetName)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetName)} to a specific player instead of broadcast");
                     }
 
                     PlayerInfo.PlayerName = reader.ReadString();
@@ -178,7 +178,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CheckColor)} to the wrong player");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CheckColor)} to the wrong player");
                     }
 
                     var color = reader.ReadByte();
@@ -190,12 +190,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetColor)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetColor)} to a specific player instead of broadcast");
                     }
 
                     PlayerInfo.ColorId = reader.ReadByte();
@@ -207,12 +207,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetHat)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
                     }
 
                     PlayerInfo.HatId = reader.ReadPackedUInt32();
@@ -223,12 +223,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetSkin)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetSkin)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
                     }
 
                     PlayerInfo.SkinId = reader.ReadPackedUInt32();
@@ -240,12 +240,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.ReportDeadBody)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.ReportDeadBody)} to a specific player instead of broadcast");
                     }
 
                     // deadBodyPlayerId can be byte.MaxValue.
@@ -269,17 +269,17 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.MurderPlayer)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.MurderPlayer)} to a specific player instead of broadcast");
                     }
 
                     if (!sender.Character.PlayerInfo.IsImpostor)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} as crewmate");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.MurderPlayer)} as crewmate");
                     }
 
                     var player = reader.ReadNetObject<InnerPlayerControl>(_game);
@@ -296,12 +296,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChat)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SendChat)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChat)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SendChat)} to a specific player instead of broadcast");
                     }
 
                     var chat = reader.ReadString();
@@ -314,12 +314,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} but was not a host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.StartMeeting)} but was not a host");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.StartMeeting)} to a specific player instead of broadcast");
                     }
 
                     var playerId = reader.ReadByte();
@@ -333,12 +333,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetScanner)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetScanner)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetScanner)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetScanner)} to a specific player instead of broadcast");
                     }
 
                     var on = reader.ReadBoolean();
@@ -350,12 +350,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChatNote)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SendChatNote)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChatNote)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SendChatNote)} to a specific player instead of broadcast");
                     }
 
                     var playerId = reader.ReadByte();
@@ -367,12 +367,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetPet)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetPet)} to a specific player instead of broadcast");
                     }
 
                     PlayerInfo.PetId = reader.ReadPackedUInt32();
@@ -384,12 +384,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetStartCounter)} to an unowned {nameof(InnerPlayerControl)}");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetStartCounter)} to an unowned {nameof(InnerPlayerControl)}");
                     }
 
                     if (target != null)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetStartCounter)} to a specific player instead of broadcast");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.SetStartCounter)} to a specific player instead of broadcast");
                     }
 
                     // Used to compare with LastStartCounter.
@@ -417,7 +417,7 @@ namespace Impostor.Server.Net.Inner.Objects
         {
             if (!sender.IsHost)
             {
-                throw new ImpostorCheatException($"Client attempted to send data for {nameof(InnerPlayerControl)} as non-host");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send data for {nameof(InnerPlayerControl)} as non-host");
             }
 
             if (initialState)

--- a/src/Impostor.Server/Net/Inner/Objects/InnerShipStatus.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerShipStatus.cs
@@ -55,12 +55,12 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CloseDoorsOfType)} to wrong destinition, must be host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CloseDoorsOfType)} to wrong destinition, must be host");
                     }
 
                     if (!sender.Character.PlayerInfo.IsImpostor)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CloseDoorsOfType)} as crewmate");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.CloseDoorsOfType)} as crewmate");
                     }
 
                     var systemType = (SystemTypes)reader.ReadByte();
@@ -72,13 +72,13 @@ namespace Impostor.Server.Net.Inner.Objects
                 {
                     if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.RepairSystem)} to wrong destinition, must be host");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.RepairSystem)} to wrong destinition, must be host");
                     }
 
                     var systemType = (SystemTypes)reader.ReadByte();
                     if (systemType == SystemTypes.Sabotage && !sender.Character.PlayerInfo.IsImpostor)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.RepairSystem)} for {systemType} as crewmate");
+                        ImpostorCheatException.ThrowIfEnabled($"Client sent {nameof(RpcCalls.RepairSystem)} for {systemType} as crewmate");
                     }
 
                     var player = reader.ReadNetObject<InnerPlayerControl>(_game);
@@ -107,12 +107,12 @@ namespace Impostor.Server.Net.Inner.Objects
         {
             if (!sender.IsHost)
             {
-                throw new ImpostorCheatException($"Client attempted to send data for {nameof(InnerShipStatus)} as non-host");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send data for {nameof(InnerShipStatus)} as non-host");
             }
 
             if (target != null)
             {
-                throw new ImpostorCheatException($"Client attempted to send {nameof(InnerShipStatus)} data to a specific player, must be broadcast");
+                ImpostorCheatException.ThrowIfEnabled($"Client attempted to send {nameof(InnerShipStatus)} data to a specific player, must be broadcast");
             }
 
             if (initialState)

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -261,7 +261,7 @@ namespace Impostor.Server.Net.State
                         // Only the host is allowed to despawn objects.
                         if (!sender.IsHost)
                         {
-                            throw new ImpostorCheatException("Tried to send SpawnFlag as non-host.");
+                            ImpostorCheatException.ThrowIfEnabled("Tried to send SpawnFlag as non-host.");
                         }
 
                         var objectId = reader.ReadPackedUInt32();

--- a/src/Impostor.Server/config-full.json
+++ b/src/Impostor.Server/config-full.json
@@ -6,6 +6,7 @@
     "ListenPort": 22023
   },
   "AntiCheat": {
+    "Enable": true,
     "BanIpFromGame": true
   },
   "ServerRedirector": {

--- a/src/Impostor.Server/config.json
+++ b/src/Impostor.Server/config.json
@@ -6,6 +6,7 @@
     "ListenPort": 22023
   },
   "AntiCheat": {
+    "Enabled": true,
     "BanIpFromGame": true
   }
 }


### PR DESCRIPTION
This could be a possible implementation of a configurable anti-cheat, without discarding packets that throw it.

Note: With the ThrowIfEnabled methods being static, there needs to be a way to access the anti cheat config (preferably without passing it around all message and packet handlers), while still following dependency injection guidelines.

Closes #117 