### PR TITLE
Send game options to single player

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 ### Description
 
 
+### Closes issues
+
 <!-- 
 
 If your pull request closes any issues, add them below with the `closes` keyword before them 
@@ -10,7 +12,5 @@ Example: closes #101
 See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 
 -->
-
-### Closes issues
 
 - closes #

--- a/src/Impostor.Api/Games/IGame.cs
+++ b/src/Impostor.Api/Games/IGame.cs
@@ -52,6 +52,14 @@ namespace Impostor.Api.Games
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
         ValueTask SyncSettingsAsync();
+        
+        /// <summary>
+        ///     Syncs the internal <see cref="GameOptionsData"/> to the specified player.
+        ///     Necessary to do if you modified it, otherwise it won't be used.
+        /// </summary>
+        /// <param name="player">The player to send the settings to.</param>
+        /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+        ValueTask SendSettingsToAsync(IInnerPlayerControl player);
 
         /// <summary>
         ///     Sets the specified list as Impostor on all connected players.

--- a/src/Impostor.Server/Net/State/Game.Api.cs
+++ b/src/Impostor.Server/Net/State/Game.Api.cs
@@ -9,6 +9,7 @@ using Impostor.Api.Net;
 using Impostor.Api.Net.Inner;
 using Impostor.Api.Net.Inner.Objects;
 using Impostor.Server.Net.Inner;
+using Impostor.Server.Net.Inner.Objects;
 
 namespace Impostor.Server.Net.State
 {
@@ -27,7 +28,7 @@ namespace Impostor.Server.Net.State
         {
             if (Host.Character == null)
             {
-                throw new ImpostorException("Attempted to set infected when the host was not spawned.");
+                throw new ImpostorException("Attempted to sync settings when the host was not spawned.");
             }
 
             using (var writer = StartRpc(Host.Character.NetId, RpcCalls.SyncSettings))
@@ -44,6 +45,30 @@ namespace Impostor.Server.Net.State
                 }
 
                 await FinishRpcAsync(writer);
+            }
+        }
+        
+        public async ValueTask SendSettingsToAsync(IInnerPlayerControl player)
+        {
+            if (Host.Character == null)
+            {
+                throw new ImpostorException("Attempted to sent settings to a player when the host was not spawned.");
+            }
+            
+            using (var writer = StartRpc(Host.Character.NetId, RpcCalls.SyncSettings))
+            {
+                // Someone will probably forget to do this, so we include it here.
+                // If this is not done, the host will overwrite changes later with the defaults.
+                Options.IsDefaults = false;
+
+                await using (var memory = new MemoryStream())
+                await using (var writerBin = new BinaryWriter(memory))
+                {
+                    Options.Serialize(writerBin, GameOptionsData.LatestVersion);
+                    writer.WriteBytesAndSize(memory.ToArray());
+                }
+
+                await FinishRpcAsync(writer, player.OwnerId);
             }
         }
 


### PR DESCRIPTION
### Description

Adds `SendSettingsToAsync`, to send settings only to a single player.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #101