### PR TITLE
OSX: Resolves 'Operation Not Supported' SocketException (Fixes #128)

### DIFF
--- a/src/Impostor.Hazel/Udp/UdpConnectionListener.cs
+++ b/src/Impostor.Hazel/Udp/UdpConnectionListener.cs
@@ -48,10 +48,15 @@ namespace Impostor.Hazel.Udp
 
             _readerPool = readerPool;
             _pool = MemoryPool<byte>.Shared;
-            _socket = new UdpClient(endPoint)
+            _socket = new UdpClient(endPoint);
+
+            try
             {
-                DontFragment = false
-            };
+                _socket.DontFragment = false;
+            }
+            catch (SocketException)
+            {
+            }
 
             _reliablePacketTimer = new Timer(ManageReliablePackets, null, 100, Timeout.Infinite);
 


### PR DESCRIPTION
Closes #128, follow-up change from [this commit](https://github.com/Impostor/Impostor/commit/b3fa60f798c6719a787f8fafe0b7ad93690ad76b).