### PR TITLE
Fix [API Bug] Task indices being cast to TaskTypes #159

### DIFF
--- a/src/Impostor.Api/Events/Game/Player/IPlayerCompletedTaskEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerCompletedTaskEvent.cs
@@ -1,9 +1,10 @@
 ﻿using Impostor.Api.Innersloth;
+using Impostor.Api.Net.Inner.Objects;
 
 namespace Impostor.Api.Events.Player
 {
     public interface IPlayerCompletedTaskEvent : IPlayerEvent
     {
-        TaskTypes Task { get; }
+        ITaskInfo Task { get; }
     }
 }

--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerInfo.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerInfo.cs
@@ -45,9 +45,9 @@ namespace Impostor.Api.Net.Inner.Objects
         ///     Gets the reason why the player is dead in the current game.
         /// </summary>
         DeathReason LastDeathReason { get; }
-        
-        List<ITaskInfo> Tasks { get; }
-        
+
+        IEnumerable<ITaskInfo> Tasks { get; }
+
         DateTimeOffset LastMurder { get; }
     }
 }

--- a/src/Impostor.Api/Net/Inner/Objects/ITaskInfo.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/ITaskInfo.cs
@@ -5,7 +5,7 @@ namespace Impostor.Api.Net.Inner.Objects
 {
     public interface ITaskInfo
     {
-        uint TaskIndex { get; }
+        uint Id { get; }
 
         TaskTypes Type { get; }
 

--- a/src/Impostor.Api/Net/Inner/Objects/ITaskInfo.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/ITaskInfo.cs
@@ -5,8 +5,10 @@ namespace Impostor.Api.Net.Inner.Objects
 {
     public interface ITaskInfo
     {
+        uint TaskIndex { get; }
+
         TaskTypes Type { get; }
-        
+
         bool Complete { get; }
     }
 }

--- a/src/Impostor.Server/Events/Game/Player/PlayerCompletedTaskEvent.cs
+++ b/src/Impostor.Server/Events/Game/Player/PlayerCompletedTaskEvent.cs
@@ -8,12 +8,12 @@ namespace Impostor.Server.Events.Player
 {
     public class PlayerCompletedTaskEvent : IPlayerCompletedTaskEvent
     {
-        public PlayerCompletedTaskEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, uint taskID)
+        public PlayerCompletedTaskEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, ITaskInfo task)
         {
             Game = game;
             ClientPlayer = clientPlayer;
             PlayerControl = playerControl;
-            Task = (TaskTypes)taskID;
+            Task = task;
         }
 
         public IGame Game { get; }
@@ -22,6 +22,6 @@ namespace Impostor.Server.Events.Player
 
         public IInnerPlayerControl PlayerControl { get; }
 
-        public TaskTypes Task { get; }
+        public ITaskInfo Task { get; }
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
@@ -1,4 +1,5 @@
-﻿using Impostor.Api.Innersloth;
+﻿using System.Threading.Tasks;
+using Impostor.Api.Innersloth;
 using Impostor.Api.Net.Inner.Objects;
 using Impostor.Api.Net.Messages;
 
@@ -8,6 +9,8 @@ namespace Impostor.Server.Net.Inner.Objects
     {
         public class TaskInfo : ITaskInfo
         {
+            public uint TaskIndex { get; internal set; }
+
             public TaskTypes Type { get; internal set; }
 
             public bool Complete { get; internal set; }
@@ -20,7 +23,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
             public void Deserialize(IMessageReader reader)
             {
-                reader.ReadPackedUInt32();
+                TaskIndex = reader.ReadPackedUInt32();
                 this.Complete = reader.ReadBoolean();
             }
         }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
@@ -20,7 +20,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
             public void Deserialize(IMessageReader reader)
             {
-                this.Type = (TaskTypes)reader.ReadPackedUInt32();
+                reader.ReadPackedUInt32();
                 this.Complete = reader.ReadBoolean();
             }
         }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Impostor.Api.Innersloth;
+﻿using Impostor.Api.Innersloth;
 using Impostor.Api.Net.Inner.Objects;
 using Impostor.Api.Net.Messages;
 
@@ -9,22 +8,22 @@ namespace Impostor.Server.Net.Inner.Objects
     {
         public class TaskInfo : ITaskInfo
         {
-            public uint TaskIndex { get; internal set; }
-
-            public TaskTypes Type { get; internal set; }
+            public uint Id { get; internal set; }
 
             public bool Complete { get; internal set; }
 
+            public TaskTypes Type { get; internal set; }
+
             public void Serialize(IMessageWriter writer)
             {
-                writer.WritePacked((uint)Type);
+                writer.WritePacked((uint)Id);
                 writer.Write(Complete);
             }
 
             public void Deserialize(IMessageReader reader)
             {
-                TaskIndex = reader.ReadPackedUInt32();
-                this.Complete = reader.ReadBoolean();
+                Id = reader.ReadPackedUInt32();
+                Complete = reader.ReadBoolean();
             }
         }
     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -173,7 +173,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 return;
             }
 
-            player.Tasks = new List<ITaskInfo>(taskTypeIds.Length);
+            player.Tasks = new List<TaskInfo>(taskTypeIds.Length);
 
             foreach (var taskId in taskTypeIds.ToArray())
             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -177,7 +177,10 @@ namespace Impostor.Server.Net.Inner.Objects
 
             foreach (var taskId in taskTypeIds.ToArray())
             {
-                player.Tasks.Add(new TaskInfo { Type = (TaskTypes)taskId });
+                player.Tasks.Add(new TaskInfo
+                {
+                    Id = taskId,
+                });
             }
         }
     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -89,9 +89,9 @@ namespace Impostor.Server.Net.Inner.Objects
                     else
                     {
                         task.Complete = true;
-                        await _eventManager.CallAsync(
-                            new PlayerCompletedTaskEvent(_game, sender, this, task));
+                        await _eventManager.CallAsync(new PlayerCompletedTaskEvent(_game, sender, this, task));
                     }
+
                     break;
                 }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -81,10 +81,17 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     var taskId = reader.ReadPackedUInt32();
-                    var task = PlayerInfo.Tasks[(int)taskId] ??= new InnerGameData.TaskInfo();
-                    task.Complete = true;
-                    await _eventManager.CallAsync(
-                        new PlayerCompletedTaskEvent(_game, sender, this, task));
+                    var task = PlayerInfo.Tasks[(int)taskId];
+                    if (task == null)
+                    {
+                        _logger.LogWarning($"Client sent {nameof(RpcCalls.CompleteTask)} with a taskIndex that is not in their {nameof(InnerPlayerInfo)}");
+                    }
+                    else
+                    {
+                        task.Complete = true;
+                        await _eventManager.CallAsync(
+                            new PlayerCompletedTaskEvent(_game, sender, this, task));
+                    }
                     break;
                 }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -81,7 +81,10 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     var taskId = reader.ReadPackedUInt32();
-                    await _eventManager.CallAsync(new PlayerCompletedTaskEvent(_game, sender, this, taskId));
+                    var task = PlayerInfo.Tasks[(int)taskId] ??= new InnerGameData.TaskInfo();
+                    task.Complete = true;
+                    await _eventManager.CallAsync(
+                        new PlayerCompletedTaskEvent(_game, sender, this, task));
                     break;
                 }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.Api.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Impostor.Api.Net.Inner.Objects;
+
+namespace Impostor.Server.Net.Inner.Objects
+{
+    internal partial class InnerPlayerInfo : IInnerPlayerInfo
+    {
+        IEnumerable<ITaskInfo> IInnerPlayerInfo.Tasks => Tasks;
+    }
+}

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
-using Impostor.Api.Net.Inner.Objects;
 using Impostor.Api.Net.Messages;
 
 namespace Impostor.Server.Net.Inner.Objects
 {
-    internal class InnerPlayerInfo : IInnerPlayerInfo
+    internal partial class InnerPlayerInfo
     {
         public InnerPlayerInfo(byte playerId)
         {
@@ -36,7 +35,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public DeathReason LastDeathReason { get; internal set; }
 
-        public List<ITaskInfo> Tasks { get; internal set; }
+        public List<InnerGameData.TaskInfo> Tasks { get; internal set; }
 
         public DateTimeOffset LastMurder { get; set; }
 
@@ -67,12 +66,10 @@ namespace Impostor.Server.Net.Inner.Objects
             IsImpostor = (flag & 2) > 0;
             IsDead = (flag & 4) > 0;
             var taskCount = reader.ReadByte();
-            Tasks = new List<ITaskInfo>();
             for (var i = 0; i < taskCount; i++)
             {
-                var task = new InnerGameData.TaskInfo();
-                task.Deserialize(reader);
-                Tasks.Add(task);
+                Tasks[i] ??= new InnerGameData.TaskInfo();
+                Tasks[i].Deserialize(reader);
             }
         }
     }


### PR DESCRIPTION
### Description
In the game, RPC SetTasks gets called with the tasks array where the taskId is in an enum, and then RPC UpdateGameData with the index of the task with respect to a `InnerPlayerInfo` and whether if its complete or not. The code now updates the `Complete` boolean by index, instead of creating a new `TaskInfo`
### Closes issues

- closes #159 
- closes #194