### PR TITLE
expose player position to api

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/Components/IInnerCustomNetworkTransform.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/Components/IInnerCustomNetworkTransform.cs
@@ -11,5 +11,11 @@ namespace Impostor.Api.Net.Inner.Objects.Components
         /// <param name="position">The target position.</param>
         /// <returns>Task that must be awaited.</returns>
         ValueTask SnapToAsync(Vector2 position);
+
+        /// <summary>
+        ///     Gets the current position <see cref="IInnerPlayerControl"/>.
+        /// </summary>
+        /// <returns>The target's position.</returns>
+        Vector2 GetPosition();
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.Api.cs
@@ -21,5 +21,10 @@ namespace Impostor.Server.Net.Inner.Objects.Components
                 await _game.FinishRpcAsync(writer);
             }
         }
+
+        public Vector2 GetPosition()
+        {
+            return _targetSyncPosition;
+        }
     }
 }


### PR DESCRIPTION
### Description
Expose _targetSyncPosition to API, so plugins can get player position.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #167 (partially?)
