### PR TITLE
Adding --errors-only argument

### DIFF
--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -19,7 +19,8 @@ namespace Impostor.Server.Net.Manager
         private static HashSet<int> SupportedVersions { get; } = new HashSet<int>
         {
             GameVersion.GetVersion(2020, 09, 07), // 2020.09.07 - 2020.09.22
-            GameVersion.GetVersion(2020, 10, 08), // 2020.10.08
+            GameVersion.GetVersion(2020, 10, 08), // 2020.10.08            
+            GameVersion.GetVersion(2020, 11, 17), // 2020.11.17
         };
 
         private readonly ILogger<ClientManager> _logger;

--- a/src/Impostor.Server/Program.cs
+++ b/src/Impostor.Server/Program.cs
@@ -40,6 +40,10 @@ namespace Impostor.Server
             {
                 logLevel = LogEventLevel.Verbose;
             }
+            else if (args.Contains("--errors-only"))
+			{
+                logLevel = LogEventLevel.Error;
+            }
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Is(logLevel)


### PR DESCRIPTION
Along with --verbose, it might be useful to have a --errors-only arg.

We use it on skeld.net so I thought I'd PR it as well.
