### PR TITLE
Upgrade OnPlayerReportedBodyEvent to OnPlayerStartMeetingEvent

### DIFF
--- a/src/Impostor.Api/Events/Game/Player/IPlayerStartMeetingEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerStartMeetingEvent.cs
@@ -2,10 +2,10 @@ using Impostor.Api.Net.Inner.Objects;
 
 namespace Impostor.Api.Events.Player
 {
-    public interface IPlayerReportedBodyEvent : IPlayerEvent
+    public interface IPlayerStartMeetingEvent : IPlayerEvent
     {
         /// <summary>
-        ///     Gets the player who's body got reported.
+        ///     Gets the player who's body got reported. Is null when the meeting started by Emergency call button
         /// </summary>
         IInnerPlayerControl? Body { get; }
     }

--- a/src/Impostor.Plugins.Example/Handlers/PlayerEventListener.cs
+++ b/src/Impostor.Plugins.Example/Handlers/PlayerEventListener.cs
@@ -92,9 +92,9 @@ namespace Impostor.Plugins.Example.Handlers
         }
 
         [EventListener]
-        public void OnPlayerReportedBodyEvent(IPlayerReportedBodyEvent e)
+        public void OnPlayerStartMeetingEvent(IPlayerStartMeetingEvent e)
         {
-            _logger.LogDebug("Player reported body");
+            _logger.LogDebug($"Player {e.PlayerControl.PlayerInfo.PlayerName} start meeting, reason: " + (e.Body==null ? "Emergency call button" : "Found the body of the player "+e.Body.PlayerInfo.PlayerName));
         }
     }
 }

--- a/src/Impostor.Server/Events/Game/Player/PlayerStartMeetingEvent.cs
+++ b/src/Impostor.Server/Events/Game/Player/PlayerStartMeetingEvent.cs
@@ -5,9 +5,9 @@ using Impostor.Api.Net.Inner.Objects;
 
 namespace Impostor.Server.Events.Player
 {
-    public class PlayerReportedBodyEvent : IPlayerReportedBodyEvent
+    public class PlayerStartMeetingEvent : IPlayerStartMeetingEvent
     {
-        public PlayerReportedBodyEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, IInnerPlayerControl? body)
+        public PlayerStartMeetingEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, IInnerPlayerControl? body)
         {
             Game = game;
             ClientPlayer = clientPlayer;

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -237,6 +237,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 }
 
                 // TODO: (ANTICHEAT) Location check?
+                // only called by a non-host player on to start meeting
                 case RpcCalls.ReportDeadBody:
                 {
                     if (!sender.IsOwner(this))
@@ -249,19 +250,10 @@ namespace Impostor.Server.Net.Inner.Objects
                         throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to a specific player instead of broadcast");
                     }
 
-                    // deadBodyPlayerId can be byte.MaxValue.
-                    // It happens when internally PlayerInfo is null.
+
                     var deadBodyPlayerId = reader.ReadByte();
-                    var deadPlayer = deadBodyPlayerId != byte.MaxValue
-                        ? _game.GameNet.GameData.GetPlayerById(deadBodyPlayerId)?.Controller
-                        : null;
+                    // deadBodyPlayerId == byte.MaxValue -- means emergency call by button
 
-                    if (deadBodyPlayerId == byte.MaxValue)
-                    {
-                        _logger.LogWarning("deadBodyPlayerId was byte.MaxValue");
-                    }
-
-                    await _eventManager.CallAsync(new PlayerReportedBodyEvent(_game, sender, this, deadPlayer));
                     break;
                 }
 
@@ -330,10 +322,13 @@ namespace Impostor.Server.Net.Inner.Objects
                         throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} to a specific player instead of broadcast");
                     }
 
-                    var playerId = reader.ReadByte();
-                    var player = _game.GameNet.GameData.GetPlayerById(playerId);
+                    // deadBodyPlayerId == byte.MaxValue -- means emergency call by button
+                    var deadBodyPlayerId = reader.ReadByte();
+                    var deadPlayer = deadBodyPlayerId != byte.MaxValue
+                        ? _game.GameNet.GameData.GetPlayerById(deadBodyPlayerId)?.Controller
+                        : null;
 
-                    // Meeting started by "player", can also be null.
+                    await _eventManager.CallAsync(new PlayerStartMeetingEvent(_game, _game.GetClientPlayer(this.OwnerId), this, deadPlayer));
                     break;
                 }
 


### PR DESCRIPTION
### Description
now also triggers on actions of the host player and before spawning Meeting HUD

`clientPlayer`, `playerControl` - caller
`Body` - the player who's body got reported or is null when the meeting started by Emergency call button

### Closes issues

- closes #127
