### PR TITLE
[API] Added missing data to IGamePlayerJoinedEvent and IGamePlayerLeftEvent

### DIFF
--- a/src/Impostor.Api/Events/Game/IGamePlayerJoinedEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerJoinedEvent.cs
@@ -1,4 +1,6 @@
-﻿namespace Impostor.Api.Events
+using Impostor.Api.Net;
+
+namespace Impostor.Api.Events
 {
     public interface IGamePlayerJoinedEvent : IGameEvent
     {

--- a/src/Impostor.Api/Events/Game/IGamePlayerJoinedEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerJoinedEvent.cs
@@ -1,4 +1,5 @@
 using Impostor.Api.Net;
+using Impostor.Api.Net.Inner.Objects;
 
 namespace Impostor.Api.Events
 {
@@ -6,6 +7,7 @@ namespace Impostor.Api.Events
     {
         /// <summary>
         ///     Gets the <see cref="IClientPlayer"/> which triggered the event.
+        ///     The <see cref="IInnerPlayerControl"/> Character of this object is null since the Character object didn't spawn yet.
         /// </summary>
         IClientPlayer Player { get; }
     }

--- a/src/Impostor.Api/Events/Game/IGamePlayerJoinedEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerJoinedEvent.cs
@@ -2,5 +2,9 @@
 {
     public interface IGamePlayerJoinedEvent : IGameEvent
     {
+        /// <summary>
+        ///     Gets the <see cref="IClientPlayer"/> which triggered the event.
+        /// </summary>
+        IClientPlayer Player { get; }
     }
 }

--- a/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
@@ -2,5 +2,9 @@
 {
     public interface IGamePlayerLeftEvent : IGameEvent
     {
+        /// <summary>
+        ///     Gets the <see cref="IClientPlayer"/> which triggered the event.
+        /// </summary>
+        IClientPlayer Player { get; }
     }
 }

--- a/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
@@ -6,5 +6,10 @@
         ///     Gets the <see cref="IClientPlayer"/> which triggered the event.
         /// </summary>
         IClientPlayer Player { get; }
+        
+        /// <summary>
+        ///     Gets the the info if the player was banned or just left
+        /// </summary>
+        bool IsBan { get; }
     }
 }

--- a/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
@@ -1,4 +1,6 @@
-﻿namespace Impostor.Api.Events
+using Impostor.Api.Net;
+
+namespace Impostor.Api.Events
 {
     public interface IGamePlayerLeftEvent : IGameEvent
     {

--- a/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGamePlayerLeftEvent.cs
@@ -6,11 +6,12 @@ namespace Impostor.Api.Events
     {
         /// <summary>
         ///     Gets the <see cref="IClientPlayer"/> which triggered the event.
+        ///     The <see cref="IInnerPlayerControl"/> Character of this object is null since the Character object was already disposed.
         /// </summary>
         IClientPlayer Player { get; }
-        
+
         /// <summary>
-        ///     Gets the the info if the player was banned or just left
+        ///     Gets a value indicating whether the player was banned or just left.
         /// </summary>
         bool IsBan { get; }
     }


### PR DESCRIPTION
### Description

Add the possibility to get the Player that left or joined

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #210
