### PR TITLE
Replace ColorId, HatId, PetId, SkinId with their respective enums

### DIFF
--- a/src/Impostor.Api/Innersloth/Customization/HatType.cs
+++ b/src/Impostor.Api/Innersloth/Customization/HatType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Impostor.Api.Innersloth.Customization
 {
-    public enum HatType
+    public enum HatType : uint
     {
         NoHat = 0,
         Astronaut = 1,
@@ -45,8 +45,8 @@
         ThirdEyeHat = 40,
         ToiletPaperHat = 41,
         Toppat = 42,
-        Fedora = 43,
-        Goggles2 = 44,
+        BlackFedora = 43,
+        SkiGoggles = 44,
         Headphones = 45,
         MaskHat = 46,
         PaperMask = 47,
@@ -58,7 +58,7 @@
         Cheese = 53,
         Cherry = 54,
         Egg = 55,
-        Fedora2 = 56,
+        GreenFedora = 56,
         Flamingo = 57,
         FlowerPin = 58,
         Helmet = 59,
@@ -95,6 +95,7 @@
         MiniCrewmate = 90,
         NinjaMask = 91,
         RamHorns = 92,
-        Snowman2 = 93,
+        SnowCrewmate = 93,
+        GeoffHat = 94,
     }
 }

--- a/src/Impostor.Api/Innersloth/Customization/PetType.cs
+++ b/src/Impostor.Api/Innersloth/Customization/PetType.cs
@@ -1,6 +1,6 @@
 namespace Impostor.Api.Innersloth.Customization
 {
-    public enum PetType
+    public enum PetType : uint
     {
         NoPet = 0,
         Alien = 1,

--- a/src/Impostor.Api/Innersloth/Customization/SkinType.cs
+++ b/src/Impostor.Api/Innersloth/Customization/SkinType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Impostor.Api.Innersloth.Customization
 {
-    public enum SkinType : byte
+    public enum SkinType : uint
     {
         None = 0,
         Astro = 1,

--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
@@ -41,48 +41,32 @@ namespace Impostor.Api.Net.Inner.Objects
         ///     Sets the color of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
-        /// <param name="colorId">A color for the player.</param>
-        /// <returns>Task that must be awaited.</returns>
-        ValueTask SetColorAsync(byte colorId);
-
         /// <param name="colorType">A color for the player.</param>
-        /// <inheritdoc cref="SetColorAsync(byte)" />
+        /// <returns>Task that must be awaited.</returns>
         ValueTask SetColorAsync(ColorType colorType);
 
         /// <summary>
         ///     Sets the hat of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
-        /// <param name="hatId">An hat for the player.</param>
-        /// <returns>Task that must be awaited.</returns>
-        ValueTask SetHatAsync(uint hatId);
-
         /// <param name="hatType">An hat for the player.</param>
-        /// <inheritdoc cref="SetHatAsync(uint)" />
+        /// <returns>Task that must be awaited.</returns>
         ValueTask SetHatAsync(HatType hatType);
 
         /// <summary>
         ///     Sets the pet of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
-        /// <param name="petId">A pet for the player.</param>
-        /// <returns>Task that must be awaited.</returns>
-        ValueTask SetPetAsync(uint petId);
-
         /// <param name="petType">A pet for the player.</param>
-        /// <inheritdoc cref="SetPetAsync(uint)" />
+        /// <returns>Task that must be awaited.</returns>
         ValueTask SetPetAsync(PetType petType);
 
         /// <summary>
         ///     Sets the skin of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
-        /// <param name="skinId">A skin for the player.</param>
-        /// <returns>Task that must be awaited.</returns>
-        ValueTask SetSkinAsync(uint skinId);
-
         /// <param name="skinType">A skin for the player.</param>
-        /// <inheritdoc cref="SetSkinAsync(uint)" />
+        /// <returns>Task that must be awaited.</returns>
         ValueTask SetSkinAsync(SkinType skinType);
 
         /// <summary>

--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerInfo.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Impostor.Api.Innersloth;
+using Impostor.Api.Innersloth.Customization;
 
 namespace Impostor.Api.Net.Inner.Objects
 {
@@ -14,22 +15,22 @@ namespace Impostor.Api.Net.Inner.Objects
         /// <summary>
         ///     Gets the color of the player.
         /// </summary>
-        byte ColorId { get; }
+        ColorType Color { get; }
 
         /// <summary>
         ///     Gets the hat of the player.
         /// </summary>
-        uint HatId { get; }
+        HatType Hat { get; }
 
         /// <summary>
         ///     Gets the pet of the player.
         /// </summary>
-        uint PetId { get; }
+        PetType Pet { get; }
 
         /// <summary>
         ///     Gets the skin of the player.
         /// </summary>
-        uint SkinId { get; }
+        SkinType Skin { get; }
 
         /// <summary>
         ///     Gets a value indicating whether the player is an impostor.

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -26,60 +26,40 @@ namespace Impostor.Server.Net.Inner.Objects
             await _game.FinishRpcAsync(writer);
         }
 
-        public async ValueTask SetColorAsync(byte colorId)
+        public async ValueTask SetColorAsync(ColorType color)
         {
-            PlayerInfo.ColorId = colorId;
+            PlayerInfo.Color = color;
 
             using var writer = _game.StartRpc(NetId, RpcCalls.SetColor);
-            writer.Write(colorId);
+            writer.Write((byte)color);
             await _game.FinishRpcAsync(writer);
         }
 
-        public ValueTask SetColorAsync(ColorType colorType)
+        public async ValueTask SetHatAsync(HatType hat)
         {
-            return SetColorAsync((byte)colorType);
-        }
-
-        public async ValueTask SetHatAsync(uint hatId)
-        {
-            PlayerInfo.HatId = hatId;
+            PlayerInfo.Hat = hat;
 
             using var writer = _game.StartRpc(NetId, RpcCalls.SetHat);
-            writer.WritePacked(hatId);
+            writer.WritePacked((uint)hat);
             await _game.FinishRpcAsync(writer);
         }
 
-        public ValueTask SetHatAsync(HatType hatType)
+        public async ValueTask SetPetAsync(PetType pet)
         {
-            return SetHatAsync((uint)hatType);
-        }
-
-        public async ValueTask SetPetAsync(uint petId)
-        {
-            PlayerInfo.PetId = petId;
+            PlayerInfo.Pet = pet;
 
             using var writer = _game.StartRpc(NetId, RpcCalls.SetPet);
-            writer.WritePacked(petId);
+            writer.WritePacked((uint)pet);
             await _game.FinishRpcAsync(writer);
         }
 
-        public ValueTask SetPetAsync(PetType petType)
+        public async ValueTask SetSkinAsync(SkinType skin)
         {
-            return SetPetAsync((uint)petType);
-        }
-
-        public async ValueTask SetSkinAsync(uint skinId)
-        {
-            PlayerInfo.SkinId = skinId;
+            PlayerInfo.Skin = skin;
 
             using var writer = _game.StartRpc(NetId, RpcCalls.SetSkin);
-            writer.WritePacked(skinId);
+            writer.WritePacked((uint)skin);
             await _game.FinishRpcAsync(writer);
-        }
-
-        public ValueTask SetSkinAsync(SkinType skinType)
-        {
-            return SetSkinAsync((uint)skinType);
         }
 
         public async ValueTask SendChatAsync(string text)

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Impostor.Api;
 using Impostor.Api.Events.Managers;
 using Impostor.Api.Innersloth;
+using Impostor.Api.Innersloth.Customization;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Messages;
 using Impostor.Server.Events.Player;
@@ -209,7 +210,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} to a specific player instead of broadcast");
                     }
 
-                    PlayerInfo.ColorId = reader.ReadByte();
+                    PlayerInfo.Color = (ColorType) reader.ReadByte();
                     break;
                 }
 
@@ -226,7 +227,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
                     }
 
-                    PlayerInfo.HatId = reader.ReadPackedUInt32();
+                    PlayerInfo.Hat = (HatType) reader.ReadPackedUInt32();
                     break;
                 }
 
@@ -242,7 +243,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
                     }
 
-                    PlayerInfo.SkinId = reader.ReadPackedUInt32();
+                    PlayerInfo.Skin = (SkinType) reader.ReadPackedUInt32();
                     break;
                 }
 
@@ -388,7 +389,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to a specific player instead of broadcast");
                     }
 
-                    PlayerInfo.PetId = reader.ReadPackedUInt32();
+                    PlayerInfo.Pet = (PetType) reader.ReadPackedUInt32();
                     break;
                 }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
+using Impostor.Api.Innersloth.Customization;
 using Impostor.Api.Net.Messages;
 
 namespace Impostor.Server.Net.Inner.Objects
@@ -19,13 +20,13 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public string PlayerName { get; internal set; }
 
-        public byte ColorId { get; internal set; }
+        public ColorType Color { get; internal set; }
 
-        public uint HatId { get; internal set; }
+        public HatType Hat { get; internal set; }
 
-        public uint PetId { get; internal set; }
+        public PetType Pet { get; internal set; }
 
-        public uint SkinId { get; internal set; }
+        public SkinType Skin { get; internal set; }
 
         public bool Disconnected { get; internal set; }
 
@@ -57,10 +58,10 @@ namespace Impostor.Server.Net.Inner.Objects
         public void Deserialize(IMessageReader reader)
         {
             PlayerName = reader.ReadString();
-            ColorId = reader.ReadByte();
-            HatId = reader.ReadPackedUInt32();
-            PetId = reader.ReadPackedUInt32();
-            SkinId = reader.ReadPackedUInt32();
+            Color = (ColorType) reader.ReadByte();
+            Hat = (HatType) reader.ReadPackedUInt32();
+            Pet = (PetType) reader.ReadPackedUInt32();
+            Skin = (SkinType) reader.ReadPackedUInt32();
             var flag = reader.ReadByte();
             Disconnected = (flag & 1) > 0;
             IsImpostor = (flag & 2) > 0;


### PR DESCRIPTION
### Description

Replace character customization ids with enums to reduce redundancy. Enums are compiled to numbers (type is specified after enum name) at runtime, so you can just use 
```cs
IInnerPlayerControl.SetSkinAsync((SkinType) 123);
``` 
anyway.

### Closes issues

- closes #161
