### PR TITLE
Cancellable Game Data RPC message Events

### DIFF
--- a/src/Impostor.Api/Events/Game/Player/IPlayerChatEvent.cs
+++ b/src/Impostor.Api/Events/Game/Player/IPlayerChatEvent.cs
@@ -1,6 +1,6 @@
-﻿namespace Impostor.Api.Events.Player
+namespace Impostor.Api.Events.Player
 {
-    public interface IPlayerChatEvent : IPlayerEvent
+    public interface IPlayerChatEvent : IPlayerEvent, ICancellableEvent
     {
         /// <summary>
         ///     Gets the message sent by the player.

--- a/src/Impostor.Api/Events/ICancellableEvent.cs
+++ b/src/Impostor.Api/Events/ICancellableEvent.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Impostor.Api.Events
+{
+    public interface ICancellableEvent
+    {
+        public Action<bool> CancelEvent { get; }
+    }
+}

--- a/src/Impostor.Server/Events/Game/Player/PlayerChatEvent.cs
+++ b/src/Impostor.Server/Events/Game/Player/PlayerChatEvent.cs
@@ -1,4 +1,5 @@
-﻿using Impostor.Api.Events.Player;
+using System;
+using Impostor.Api.Events.Player;
 using Impostor.Api.Games;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Inner.Objects;
@@ -7,12 +8,13 @@ namespace Impostor.Server.Events.Player
 {
     public class PlayerChatEvent : IPlayerChatEvent
     {
-        public PlayerChatEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, string message)
+        public PlayerChatEvent(IGame game, IClientPlayer clientPlayer, IInnerPlayerControl playerControl, string message, Action<bool> cancelEvent)
         {
             Game = game;
             ClientPlayer = clientPlayer;
             PlayerControl = playerControl;
             Message = message;
+            CancelEvent = cancelEvent;
         }
 
         public IGame Game { get; }
@@ -22,5 +24,7 @@ namespace Impostor.Server.Events.Player
         public IInnerPlayerControl PlayerControl { get; }
 
         public string Message { get; }
+
+        public Action<bool> CancelEvent { get; }
     }
 }

--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -153,8 +153,9 @@ namespace Impostor.Server.Net
                     // TODO: Return value, either a bool (to cancel) or a writer (to cancel (null) or modify/overwrite).
                     try
                     {
-                        var verified = await Player.Game.HandleGameDataAsync(readerCopy, Player, toPlayer);
-                        if (verified)
+                        var eventCancelled = false;
+                        var verified = await Player.Game.HandleGameDataAsync(readerCopy, Player, toPlayer, (cancel) => eventCancelled = cancel);
+                        if (verified && !eventCancelled)
                         {
                             // Broadcast packet to all other players.
                             using (var writer = MessageWriter.Get(messageType))

--- a/src/Impostor.Server/Net/Inner/InnerNetObject.cs
+++ b/src/Impostor.Server/Net/Inner/InnerNetObject.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Threading.Tasks;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Inner;
 using Impostor.Api.Net.Messages;
@@ -16,7 +17,7 @@ namespace Impostor.Server.Net.Inner
 
         public SpawnFlags SpawnFlags { get; internal set; }
 
-        public abstract ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader);
+        public abstract ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent);
 
         public abstract bool Serialize(IMessageWriter writer, bool initialState);
 

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+using System;
+using System.Numerics;
 using System.Threading.Tasks;
 using Impostor.Api;
 using Impostor.Api.Innersloth;
@@ -52,7 +53,7 @@ namespace Impostor.Server.Net.Inner.Objects.Components
             return new Vector2(XRange.Lerp(v1), YRange.Lerp(v2));
         }
 
-        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             if (call == RpcCalls.SnapTo)
             {

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -26,7 +26,7 @@ namespace Impostor.Server.Net.Inner.Objects.Components
             _game = game;
         }
 
-        public override async ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override async ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             if (call != RpcCalls.EnterVent && call != RpcCalls.ExitVent)
             {

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerVoteBanSystem.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerVoteBanSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Impostor.Api;
@@ -21,7 +21,7 @@ namespace Impostor.Server.Net.Inner.Objects.Components
             _votes = new Dictionary<int, int[]>();
         }
 
-        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             if (call != RpcCalls.AddVote)
             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace Impostor.Server.Net.Inner.Objects
             _logger = logger;
             _game = game;
             _allPlayers = new ConcurrentDictionary<byte, InnerPlayerInfo>();
-
+            
             Components.Add(this);
             Components.Add(ActivatorUtilities.CreateInstance<InnerVoteBanSystem>(serviceProvider));
         }
@@ -44,7 +44,7 @@ namespace Impostor.Server.Net.Inner.Objects
             return _allPlayers.TryGetValue(id, out var player) ? player : null;
         }
 
-        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             switch (call)
             {
@@ -128,7 +128,7 @@ namespace Impostor.Server.Net.Inner.Objects
             if (initialState)
             {
                 var num = reader.ReadPackedInt32();
-
+                
                 for (var i = 0; i < num; i++)
                 {
                     var playerId = reader.ReadByte();

--- a/src/Impostor.Server/Net/Inner/Objects/InnerLobbyBehaviour.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerLobbyBehaviour.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Threading.Tasks;
 using Impostor.Api.Games;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Inner.Objects;
@@ -18,7 +19,7 @@ namespace Impostor.Server.Net.Inner.Objects
             Components.Add(this);
         }
 
-        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Impostor.Api;
@@ -46,7 +46,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 .ToArray();
         }
 
-        public override async ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override async ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             switch (call)
             {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -316,7 +316,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
                         var chat = reader.ReadString();
 
-                        await _eventManager.CallAsync(new PlayerChatEvent(_game, sender, this, chat));
+                        await _eventManager.CallAsync(new PlayerChatEvent(_game, sender, this, chat, cancelEvent));
                         break;
                     }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -46,383 +46,383 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public InnerPlayerInfo PlayerInfo { get; internal set; }
 
-        public override async ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        public override async ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader, Action<bool> cancelEvent)
         {
             switch (call)
             {
                 // Play an animation.
                 case RpcCalls.PlayAnimation:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.PlayAnimation)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.PlayAnimation)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.PlayAnimation)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.PlayAnimation)} to a specific player instead of broadcast");
+                        }
 
-                    var animation = reader.ReadByte();
-                    break;
-                }
+                        var animation = reader.ReadByte();
+                        break;
+                    }
 
                 // Complete a task.
                 case RpcCalls.CompleteTask:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CompleteTask)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CompleteTask)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CompleteTask)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CompleteTask)} to a specific player instead of broadcast");
+                        }
 
-                    var taskId = reader.ReadPackedUInt32();
-                    var task = PlayerInfo.Tasks[(int)taskId];
-                    if (task == null)
-                    {
-                        _logger.LogWarning($"Client sent {nameof(RpcCalls.CompleteTask)} with a taskIndex that is not in their {nameof(InnerPlayerInfo)}");
-                    }
-                    else
-                    {
-                        task.Complete = true;
-                        await _eventManager.CallAsync(new PlayerCompletedTaskEvent(_game, sender, this, task));
-                    }
+                        var taskId = reader.ReadPackedUInt32();
+                        var task = PlayerInfo.Tasks[(int)taskId];
+                        if (task == null)
+                        {
+                            _logger.LogWarning($"Client sent {nameof(RpcCalls.CompleteTask)} with a taskIndex that is not in their {nameof(InnerPlayerInfo)}");
+                        }
+                        else
+                        {
+                            task.Complete = true;
+                            await _eventManager.CallAsync(new PlayerCompletedTaskEvent(_game, sender, this, task));
+                        }
 
-                    break;
-                }
+                        break;
+                    }
 
                 // Update GameOptions.
                 case RpcCalls.SyncSettings:
-                {
-                    if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SyncSettings)} but was not a host");
-                    }
+                        if (!sender.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SyncSettings)} but was not a host");
+                        }
 
-                    _game.Options.Deserialize(reader.ReadBytesAndSize());
-                    break;
-                }
+                        _game.Options.Deserialize(reader.ReadBytesAndSize());
+                        break;
+                    }
 
                 // Set Impostors.
                 case RpcCalls.SetInfected:
-                {
-                    if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetInfected)} but was not a host");
-                    }
-
-                    var length = reader.ReadPackedInt32();
-
-                    for (var i = 0; i < length; i++)
-                    {
-                        var playerId = reader.ReadByte();
-                        var player = _game.GameNet.GameData.GetPlayerById(playerId);
-                        if (player != null)
+                        if (!sender.IsHost)
                         {
-                            player.IsImpostor = true;
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetInfected)} but was not a host");
                         }
-                    }
 
-                    if (_game.GameState == GameStates.Starting)
-                    {
-                        await _game.StartedAsync();
-                    }
+                        var length = reader.ReadPackedInt32();
 
-                    break;
-                }
+                        for (var i = 0; i < length; i++)
+                        {
+                            var playerId = reader.ReadByte();
+                            var player = _game.GameNet.GameData.GetPlayerById(playerId);
+                            if (player != null)
+                            {
+                                player.IsImpostor = true;
+                            }
+                        }
+
+                        if (_game.GameState == GameStates.Starting)
+                        {
+                            await _game.StartedAsync();
+                        }
+
+                        break;
+                    }
 
                 // Player was voted out.
                 case RpcCalls.Exiled:
-                {
-                    if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Exiled)} but was not a host");
+                        if (!sender.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Exiled)} but was not a host");
+                        }
+
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Exiled)} to a specific player instead of broadcast");
+                        }
+
+                        // TODO: Not hit?
+                        Die(DeathReason.Exile);
+
+                        await _eventManager.CallAsync(new PlayerExileEvent(_game, sender, this));
+                        break;
                     }
-
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.Exiled)} to a specific player instead of broadcast");
-                    }
-
-                    // TODO: Not hit?
-                    Die(DeathReason.Exile);
-
-                    await _eventManager.CallAsync(new PlayerExileEvent(_game, sender, this));
-                    break;
-                }
 
                 // Validates the player name at the host.
                 case RpcCalls.CheckName:
-                {
-                    if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CheckName)} to the wrong player");
-                    }
+                        if (target == null || !target.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CheckName)} to the wrong player");
+                        }
 
-                    var name = reader.ReadString();
-                    break;
-                }
+                        var name = reader.ReadString();
+                        break;
+                    }
 
                 // Update the name of a player.
                 case RpcCalls.SetName:
-                {
-                    if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetName)} but was not a host");
-                    }
+                        if (!sender.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetName)} but was not a host");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetName)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetName)} to a specific player instead of broadcast");
+                        }
 
-                    PlayerInfo.PlayerName = reader.ReadString();
-                    break;
-                }
+                        PlayerInfo.PlayerName = reader.ReadString();
+                        break;
+                    }
 
                 // Validates the color at the host.
                 case RpcCalls.CheckColor:
-                {
-                    if (target == null || !target.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CheckColor)} to the wrong player");
-                    }
+                        if (target == null || !target.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.CheckColor)} to the wrong player");
+                        }
 
-                    var color = reader.ReadByte();
-                    break;
-                }
+                        var color = reader.ReadByte();
+                        break;
+                    }
 
                 // Update the color of a player.
                 case RpcCalls.SetColor:
-                {
-                    if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} but was not a host");
-                    }
+                        if (!sender.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} but was not a host");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetColor)} to a specific player instead of broadcast");
+                        }
 
-                    PlayerInfo.ColorId = reader.ReadByte();
-                    break;
-                }
+                        PlayerInfo.ColorId = reader.ReadByte();
+                        break;
+                    }
 
                 // Update the hat of a player.
                 case RpcCalls.SetHat:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
+                        }
 
-                    PlayerInfo.HatId = reader.ReadPackedUInt32();
-                    break;
-                }
+                        PlayerInfo.HatId = reader.ReadPackedUInt32();
+                        break;
+                    }
 
                 case RpcCalls.SetSkin:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetSkin)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetSkin)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetHat)} to a specific player instead of broadcast");
+                        }
 
-                    PlayerInfo.SkinId = reader.ReadPackedUInt32();
-                    break;
-                }
+                        PlayerInfo.SkinId = reader.ReadPackedUInt32();
+                        break;
+                    }
 
                 // TODO: (ANTICHEAT) Location check?
                 // only called by a non-host player on to start meeting
                 case RpcCalls.ReportDeadBody:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to an unowned {nameof(InnerPlayerControl)}");
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
+
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to a specific player instead of broadcast");
+                        }
+
+
+                        var deadBodyPlayerId = reader.ReadByte();
+                        // deadBodyPlayerId == byte.MaxValue -- means emergency call by button
+
+                        break;
                     }
-
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.ReportDeadBody)} to a specific player instead of broadcast");
-                    }
-
-
-                    var deadBodyPlayerId = reader.ReadByte();
-                    // deadBodyPlayerId == byte.MaxValue -- means emergency call by button
-
-                    break;
-                }
 
                 // TODO: (ANTICHEAT) Cooldown check?
                 case RpcCalls.MurderPlayer:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} to an unowned {nameof(InnerPlayerControl)}");
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
+
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} to a specific player instead of broadcast");
+                        }
+
+                        if (!sender.Character.PlayerInfo.IsImpostor)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} as crewmate");
+                        }
+
+                        if (!sender.Character.PlayerInfo.CanMurder(_game))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} too fast");
+                        }
+
+                        sender.Character.PlayerInfo.LastMurder = DateTimeOffset.UtcNow;
+
+                        var player = reader.ReadNetObject<InnerPlayerControl>(_game);
+                        if (!player.PlayerInfo.IsDead)
+                        {
+                            player.Die(DeathReason.Kill);
+                            await _eventManager.CallAsync(new PlayerMurderEvent(_game, sender, this, player));
+                        }
+
+                        break;
                     }
-
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} to a specific player instead of broadcast");
-                    }
-
-                    if (!sender.Character.PlayerInfo.IsImpostor)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} as crewmate");
-                    }
-
-                    if (!sender.Character.PlayerInfo.CanMurder(_game))
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.MurderPlayer)} too fast");
-                    }
-
-                    sender.Character.PlayerInfo.LastMurder = DateTimeOffset.UtcNow;
-
-                    var player = reader.ReadNetObject<InnerPlayerControl>(_game);
-                    if (!player.PlayerInfo.IsDead)
-                    {
-                        player.Die(DeathReason.Kill);
-                        await _eventManager.CallAsync(new PlayerMurderEvent(_game, sender, this, player));
-                    }
-
-                    break;
-                }
 
                 case RpcCalls.SendChat:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChat)} to an unowned {nameof(InnerPlayerControl)}");
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChat)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
+
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChat)} to a specific player instead of broadcast");
+                        }
+
+                        var chat = reader.ReadString();
+
+                        await _eventManager.CallAsync(new PlayerChatEvent(_game, sender, this, chat));
+                        break;
                     }
-
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChat)} to a specific player instead of broadcast");
-                    }
-
-                    var chat = reader.ReadString();
-
-                    await _eventManager.CallAsync(new PlayerChatEvent(_game, sender, this, chat));
-                    break;
-                }
 
                 case RpcCalls.StartMeeting:
-                {
-                    if (!sender.IsHost)
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} but was not a host");
+                        if (!sender.IsHost)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} but was not a host");
+                        }
+
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} to a specific player instead of broadcast");
+                        }
+
+                        // deadBodyPlayerId == byte.MaxValue -- means emergency call by button
+                        var deadBodyPlayerId = reader.ReadByte();
+                        var deadPlayer = deadBodyPlayerId != byte.MaxValue
+                            ? _game.GameNet.GameData.GetPlayerById(deadBodyPlayerId)?.Controller
+                            : null;
+
+                        await _eventManager.CallAsync(new PlayerStartMeetingEvent(_game, _game.GetClientPlayer(this.OwnerId), this, deadPlayer));
+                        break;
                     }
-
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.StartMeeting)} to a specific player instead of broadcast");
-                    }
-
-                    // deadBodyPlayerId == byte.MaxValue -- means emergency call by button
-                    var deadBodyPlayerId = reader.ReadByte();
-                    var deadPlayer = deadBodyPlayerId != byte.MaxValue
-                        ? _game.GameNet.GameData.GetPlayerById(deadBodyPlayerId)?.Controller
-                        : null;
-
-                    await _eventManager.CallAsync(new PlayerStartMeetingEvent(_game, _game.GetClientPlayer(this.OwnerId), this, deadPlayer));
-                    break;
-                }
 
                 case RpcCalls.SetScanner:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetScanner)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetScanner)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetScanner)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetScanner)} to a specific player instead of broadcast");
+                        }
 
-                    var on = reader.ReadBoolean();
-                    var count = reader.ReadByte();
-                    break;
-                }
+                        var on = reader.ReadBoolean();
+                        var count = reader.ReadByte();
+                        break;
+                    }
 
                 case RpcCalls.SendChatNote:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChatNote)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChatNote)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChatNote)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SendChatNote)} to a specific player instead of broadcast");
+                        }
 
-                    var playerId = reader.ReadByte();
-                    var chatNote = (ChatNoteType)reader.ReadByte();
-                    break;
-                }
+                        var playerId = reader.ReadByte();
+                        var chatNote = (ChatNoteType)reader.ReadByte();
+                        break;
+                    }
 
                 case RpcCalls.SetPet:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to an unowned {nameof(InnerPlayerControl)}");
-                    }
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
 
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to a specific player instead of broadcast");
-                    }
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetPet)} to a specific player instead of broadcast");
+                        }
 
-                    PlayerInfo.PetId = reader.ReadPackedUInt32();
-                    break;
-                }
+                        PlayerInfo.PetId = reader.ReadPackedUInt32();
+                        break;
+                    }
 
                 // TODO: Understand this RPC
                 case RpcCalls.SetStartCounter:
-                {
-                    if (!sender.IsOwner(this))
                     {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetStartCounter)} to an unowned {nameof(InnerPlayerControl)}");
+                        if (!sender.IsOwner(this))
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetStartCounter)} to an unowned {nameof(InnerPlayerControl)}");
+                        }
+
+                        if (target != null)
+                        {
+                            throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetStartCounter)} to a specific player instead of broadcast");
+                        }
+
+                        // Used to compare with LastStartCounter.
+                        var startCounter = reader.ReadPackedUInt32();
+
+                        // Is either start countdown or byte.MaxValue
+                        var secondsLeft = reader.ReadByte();
+                        if (secondsLeft < byte.MaxValue)
+                        {
+                            await _eventManager.CallAsync(new PlayerSetStartCounterEvent(_game, sender, this, secondsLeft));
+                        }
+
+                        break;
                     }
-
-                    if (target != null)
-                    {
-                        throw new ImpostorCheatException($"Client sent {nameof(RpcCalls.SetStartCounter)} to a specific player instead of broadcast");
-                    }
-
-                    // Used to compare with LastStartCounter.
-                    var startCounter = reader.ReadPackedUInt32();
-
-                    // Is either start countdown or byte.MaxValue
-                    var secondsLeft = reader.ReadByte();
-                    if (secondsLeft < byte.MaxValue)
-                    {
-                        await _eventManager.CallAsync(new PlayerSetStartCounterEvent(_game, sender, this, secondsLeft));
-                    }
-
-                    break;
-                }
 
                 default:
-                {
-                    _logger.LogWarning("{0}: Unknown rpc call {1}", nameof(InnerPlayerControl), call);
-                    break;
-                }
+                    {
+                        _logger.LogWarning("{0}: Unknown rpc call {1}", nameof(InnerPlayerControl), call);
+                        break;
+                    }
             }
         }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerShipStatus.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerShipStatus.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Impostor.Api;
@@ -47,7 +47,7 @@ namespace Impostor.Server.Net.Inner.Objects
         }
 
         public override ValueTask HandleRpc(ClientPlayer sender, ClientPlayer? target, RpcCalls call,
-            IMessageReader reader)
+            IMessageReader reader, Action<bool> cancelEvent)
         {
             switch (call)
             {

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -190,7 +190,7 @@ namespace Impostor.Server.Net.State
             }
         }
 
-        public async ValueTask<bool> HandleGameDataAsync(IMessageReader parent, ClientPlayer sender, bool toPlayer)
+        public async ValueTask<bool> HandleGameDataAsync(IMessageReader parent, ClientPlayer sender, bool toPlayer, Action<bool> cancelEvent)
         {
             // Find target player.
             ClientPlayer target = null;
@@ -246,7 +246,7 @@ namespace Impostor.Server.Net.State
                         var netId = reader.ReadPackedUInt32();
                         if (_allObjectsFast.TryGetValue(netId, out var obj))
                         {
-                            await obj.HandleRpc(sender, target, (RpcCalls) reader.ReadByte(), reader);
+                            await obj.HandleRpc(sender, target, (RpcCalls) reader.ReadByte(), reader, cancelEvent);
                         }
                         else
                         {


### PR DESCRIPTION
### Description
- Implements cancel evet flag for `GameData` and `GameDataTo` client RPC message flags, which can be triggered via `CancelEvent` action.
- Implements `ICancellableEvent` which exposes `Action<bool> CancelEvent` on events
- Implements `ICancellableEvent` on `IPlayerChatEvent`

### Closes issues

- closes #257
- closes #92