### PR TITLE
Add Geoff Keighley Mask

### DIFF
--- a/src/Impostor.Api/Innersloth/Customization/HatType.cs
+++ b/src/Impostor.Api/Innersloth/Customization/HatType.cs
@@ -96,5 +96,6 @@
         NinjaMask = 91,
         RamHorns = 92,
         Snowman2 = 93,
+        GeoffKeighley = 94,
     }
 }


### PR DESCRIPTION
### Description

Add Geoff Keighley Mask to HatType.

Available on 2020.12.9 (or above)
