### PR TITLE
Add IInnerPlayerControler#SetExiledAsync

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
@@ -98,5 +98,12 @@ namespace Impostor.Api.Net.Inner.Objects
         /// <exception cref="ImpostorProtocolException">Thrown when target is dead.</exception>
         /// <returns>Task that must be awaited.</returns>
         ValueTask MurderPlayerAsync(IInnerPlayerControl target);
+
+        /// <summary>
+        ///     Exile the current player. This doesn't produce a body to be reported.
+        ///     Visible to all players.
+        /// </summary>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask ExileAsync();
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -106,5 +106,24 @@ namespace Impostor.Server.Net.Inner.Objects
 
             await _eventManager.CallAsync(new PlayerMurderEvent(_game, _game.GetClientPlayer(OwnerId), this, target));
         }
+
+        public async ValueTask ExileAsync()
+        {
+            if (PlayerInfo.IsDead)
+            {
+                throw new ImpostorProtocolException("Tried to exile a player, but target was not alive.");
+            }
+
+            // Update player.
+            Die(DeathReason.Exile);
+
+            // Send RPC.
+            using var writer = _game.StartRpc(NetId, RpcCalls.Exiled);
+            Rpc04Exiled.Serialize(writer);
+            await _game.FinishRpcAsync(writer);
+
+            // Notify plugins.
+            await _eventManager.CallAsync(new PlayerExileEvent(_game, _game.GetClientPlayer(OwnerId), this));
+        }
     }
 }


### PR DESCRIPTION
### Description
Adds a `SetExiledAsync` to `IInnerPlayerControler`. It allows to kill a player with no animation and doesn't leave a body to report.