### PR TITLE
Really fix SetInfectedAsync's packet structure

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Api.cs
+++ b/src/Impostor.Server/Net/State/Game.Api.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Impostor.Api;
@@ -56,7 +57,7 @@ namespace Impostor.Server.Net.State
 
             using (var writer = StartRpc(Host.Character.NetId, RpcCalls.SetInfected))
             {
-                writer.Write((byte)Host.Character.NetId);
+                writer.WritePacked((uint)players.Count());
 
                 foreach (var player in players)
                 {


### PR DESCRIPTION
**Description**

New Impostor list is prefixed with the list's length not the host's netid

**Use Case & Test**
https://gist.github.com/libhalt/e3f98c717a29514dcc259c6ca9c7f708
