### PR TITLE
Ban only on unbalanced name/color requests

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
@@ -19,11 +19,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public string PlayerName { get; internal set; }
 
-        public string? RequestedPlayerName { get; internal set; }
-
         public byte ColorId { get; internal set; }
-
-        public byte? RequestedColorId { get; internal set; }
 
         public uint HatId { get; internal set; }
 


### PR DESCRIPTION
Closes #286.

Will keep the check on valid names and characters in them, but remove the check for the name in the handshake. Also, name in request and response don't have to match, as it's considered a bit tricky with the current way RUDP is implemented in Hazel. (packets can arrive out-of-order). But as this would only be a minor impact, I believe it's okay.

Will remove the check on valid colors, as this might break some client mods (which add more colors) and the AmongUs server seem to handle those as well. Also, then we don't have to update the server just because they add more colors.