### PR TITLE
Warn if plugin loader paths don't exist

### DIFF
--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -24,6 +24,8 @@ namespace Impostor.Server.Plugins
             // Add the plugins and libraries.
             var pluginPaths = new List<string>(config.Paths);
             var libraryPaths = new List<string>(config.LibraryPaths);
+            CheckPaths(pluginPaths);
+            CheckPaths(libraryPaths);
 
             var rootFolder = Directory.GetCurrentDirectory();
 
@@ -118,6 +120,17 @@ namespace Impostor.Server.Plugins
             });
 
             return builder;
+        }
+
+        private static void CheckPaths(IEnumerable<string> paths)
+        {
+            foreach (var path in paths)
+            {
+                if (!Directory.Exists(path))
+                {
+                    Logger.Warning("Path {path} was specified in the PluginLoader configuration, but this folder doesn't exist!", path);
+                }
+            }
         }
 
         private static void RegisterAssemblies(


### PR DESCRIPTION
I've seen this happen a lot with plugins that need ASP.NET Core
libraries and personally also fell into it when I updated .NET and
wasn't aware I needed to change this path. Warn more explicitly, because
9/10 times the server will crash soon afterwards and this may help fix
the problem.