### PR TITLE
Send GameOptionData and player customization (Name, Color, etc...) to a specific player

### DIFF
--- a/src/Impostor.Api/Games/IGame.cs
+++ b/src/Impostor.Api/Games/IGame.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Inner;
+using Impostor.Api.Net.Inner.Objects;
 using Impostor.Api.Net.Messages;
 
 namespace Impostor.Api.Games
@@ -59,6 +60,15 @@ namespace Impostor.Api.Games
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
         ValueTask SyncSettingsAsync();
+
+        /// <summary>
+        ///     Sends a <see cref="GameOptionsData"/> to one player.
+        ///     This will desync the options to the players. Use it carfully.
+        /// </summary>
+        /// <param name="options">The <see cref="GameOptionsData"/> to send.</param>
+        /// <param name="player">The player to send the <see cref="GameOptionsData"/> to.</param>
+        /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+        ValueTask SendSettingsToPlayerAsync(GameOptionsData options, IInnerPlayerControl player);
 
         /// <summary>
         ///     Sets game's privacy.

--- a/src/Impostor.Api/Innersloth/GameOptionsData.cs
+++ b/src/Impostor.Api/Innersloth/GameOptionsData.cs
@@ -250,5 +250,14 @@ namespace Impostor.Api.Innersloth
                 throw new ImpostorException($"Unknown GameOptionsData version {Version}.");
             }
         }
+
+        /// <summary>
+        /// Create a shallow clone of the options.
+        /// </summary>
+        /// <returns>The cloned GameOptionsData.</returns>
+        public GameOptionsData Clone()
+        {
+            return (GameOptionsData)MemberwiseClone();
+        }
     }
 }

--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
@@ -38,6 +38,18 @@ namespace Impostor.Api.Net.Inner.Objects
         ValueTask SetNameAsync(string name);
 
         /// <summary>
+        ///     Sends a name for the current <see cref="IInnerPlayerControl"/> to a player.
+        ///     It doesn't change the actual name of the <see cref="IInnerPlayerControl"/>.
+        /// </summary>
+        /// <param name="name">A name for the player.</param>
+        /// <param name="player">
+        ///     The player that should receive this message.
+        ///     When left as null, will send message to self.
+        /// </param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SendNameToPlayerAsync(string name, IInnerPlayerControl? player = null);
+
+        /// <summary>
         ///     Sets the color of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
@@ -46,12 +58,36 @@ namespace Impostor.Api.Net.Inner.Objects
         ValueTask SetColorAsync(ColorType colorType);
 
         /// <summary>
+        ///     Sends a color for the current <see cref="IInnerPlayerControl"/> to a player.
+        ///     It doesn't change the actual color of the <see cref="IInnerPlayerControl"/>.
+        /// </summary>
+        /// <param name="colorType">A color for the player.</param>
+        /// <param name="player">
+        ///     The player that should receive this message.
+        ///     When left as null, will send message to self.
+        /// </param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SendColorToPlayerAsync(ColorType colorType, IInnerPlayerControl? player = null);
+
+        /// <summary>
         ///     Sets the hat of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
-        /// <param name="hatType">An hat for the player.</param>
+        /// <param name="hatType">A hat for the player.</param>
         /// <returns>Task that must be awaited.</returns>
         ValueTask SetHatAsync(HatType hatType);
+
+        /// <summary>
+        ///     Sends a hat for the current <see cref="IInnerPlayerControl"/> to a player.
+        ///     It doesn't change the actual hat of the <see cref="IInnerPlayerControl"/>.
+        /// </summary>
+        /// <param name="hatType">A hat for the player.</param>
+        /// <param name="player">
+        ///     The player that should receive this message.
+        ///     When left as null, will send message to self.
+        /// </param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SendHatToPlayerAsync(HatType hatType, IInnerPlayerControl? player = null);
 
         /// <summary>
         ///     Sets the pet of the current <see cref="IInnerPlayerControl"/>.
@@ -62,12 +98,36 @@ namespace Impostor.Api.Net.Inner.Objects
         ValueTask SetPetAsync(PetType petType);
 
         /// <summary>
+        ///     Sends a pet for the current <see cref="IInnerPlayerControl"/> to a player.
+        ///     It doesn't change the actual pet of the <see cref="IInnerPlayerControl"/>.
+        /// </summary>
+        /// <param name="petType">A pet for the player.</param>
+        /// <param name="player">
+        ///     The player that should receive this message.
+        ///     When left as null, will send message to self.
+        /// </param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SendPetToPlayerAsync(PetType petType, IInnerPlayerControl? player = null);
+
+        /// <summary>
         ///     Sets the skin of the current <see cref="IInnerPlayerControl"/>.
         ///     Visible to all players.
         /// </summary>
         /// <param name="skinType">A skin for the player.</param>
         /// <returns>Task that must be awaited.</returns>
         ValueTask SetSkinAsync(SkinType skinType);
+
+        /// <summary>
+        ///     Sends a skin for the current <see cref="IInnerPlayerControl"/> to a player.
+        ///     It doesn't change the actual skin of the <see cref="IInnerPlayerControl"/>.
+        /// </summary>
+        /// <param name="skinType">A skin for the player.</param>
+        /// <param name="player">
+        ///     The player that should receive this message.
+        ///     When left as null, will send message to self.
+        /// </param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask SendSkinToPlayerAsync(SkinType skinType, IInnerPlayerControl? player = null);
 
         /// <summary>
         ///     Send a chat message as the current <see cref="IInnerPlayerControl"/>.

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -26,6 +26,18 @@ namespace Impostor.Server.Net.Inner.Objects
             await _game.FinishRpcAsync(writer);
         }
 
+        public async ValueTask SendNameToPlayerAsync(string name, IInnerPlayerControl? player = null)
+        {
+            if (player == null)
+            {
+                player = this;
+            }
+
+            using var writer = _game.StartRpc(NetId, RpcCalls.SetName);
+            writer.Write(name);
+            await _game.FinishRpcAsync(writer, player.OwnerId);
+        }
+
         public async ValueTask SetColorAsync(ColorType color)
         {
             PlayerInfo.Color = color;
@@ -33,6 +45,18 @@ namespace Impostor.Server.Net.Inner.Objects
             using var writer = _game.StartRpc(NetId, RpcCalls.SetColor);
             Rpc08SetColor.Serialize(writer, color);
             await _game.FinishRpcAsync(writer);
+        }
+
+        public async ValueTask SendColorToPlayerAsync(ColorType color, IInnerPlayerControl? player = null)
+        {
+            if (player == null)
+            {
+                player = this;
+            }
+
+            using var writer = _game.StartRpc(NetId, RpcCalls.SetColor);
+            Rpc08SetColor.Serialize(writer, color);
+            await _game.FinishRpcAsync(writer, player.OwnerId);
         }
 
         public async ValueTask SetHatAsync(HatType hat)
@@ -44,6 +68,18 @@ namespace Impostor.Server.Net.Inner.Objects
             await _game.FinishRpcAsync(writer);
         }
 
+        public async ValueTask SendHatToPlayerAsync(HatType hat, IInnerPlayerControl? player = null)
+        {
+            if (player == null)
+            {
+                player = this;
+            }
+
+            using var writer = _game.StartRpc(NetId, RpcCalls.SetHat);
+            Rpc09SetHat.Serialize(writer, hat);
+            await _game.FinishRpcAsync(writer, player.OwnerId);
+        }
+
         public async ValueTask SetPetAsync(PetType pet)
         {
             PlayerInfo.Pet = pet;
@@ -53,6 +89,18 @@ namespace Impostor.Server.Net.Inner.Objects
             await _game.FinishRpcAsync(writer);
         }
 
+        public async ValueTask SendPetToPlayerAsync(PetType pet, IInnerPlayerControl? player = null)
+        {
+            if (player == null)
+            {
+                player = this;
+            }
+
+            using var writer = _game.StartRpc(NetId, RpcCalls.SetPet);
+            Rpc17SetPet.Serialize(writer, pet);
+            await _game.FinishRpcAsync(writer, player.OwnerId);
+        }
+
         public async ValueTask SetSkinAsync(SkinType skin)
         {
             PlayerInfo.Skin = skin;
@@ -60,6 +108,18 @@ namespace Impostor.Server.Net.Inner.Objects
             using var writer = _game.StartRpc(NetId, RpcCalls.SetSkin);
             Rpc10SetSkin.Serialize(writer, skin);
             await _game.FinishRpcAsync(writer);
+        }
+
+        public async ValueTask SendSkinToPlayerAsync(SkinType skin, IInnerPlayerControl? player = null)
+        {
+            if (player == null)
+            {
+                player = this;
+            }
+
+            using var writer = _game.StartRpc(NetId, RpcCalls.SetSkin);
+            Rpc10SetSkin.Serialize(writer, skin);
+            await _game.FinishRpcAsync(writer, player.OwnerId);
         }
 
         public async ValueTask SendChatAsync(string text)

--- a/src/Impostor.Server/Net/State/Game.Api.cs
+++ b/src/Impostor.Server/Net/State/Game.Api.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using Impostor.Api;
@@ -6,6 +6,7 @@ using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Inner;
+using Impostor.Api.Net.Inner.Objects;
 using Impostor.Api.Net.Messages;
 using Impostor.Hazel;
 using Impostor.Server.Net.Inner;
@@ -44,6 +45,26 @@ namespace Impostor.Server.Net.State
                 }
 
                 await FinishRpcAsync(writer);
+            }
+        }
+
+        public async ValueTask SendSettingsToPlayerAsync(GameOptionsData options, IInnerPlayerControl player)
+        {
+            if (Host.Character == null)
+            {
+                throw new ImpostorException("Attempted to set infected when the host was not spawned.");
+            }
+
+            using (var writer = StartRpc(Host.Character.NetId, RpcCalls.SyncSettings))
+            {
+                await using (var memory = new MemoryStream())
+                await using (var writerBin = new BinaryWriter(memory))
+                {
+                    options.Serialize(writerBin, GameOptionsData.LatestVersion);
+                    writer.WriteBytesAndSize(memory.ToArray());
+                }
+
+                await FinishRpcAsync(writer, player.OwnerId);
             }
         }
 


### PR DESCRIPTION
Allow to desync GameOptionData and player customization.
Things you can do :
- Set the name, color, hat, skin and pet of a player to be only visible by them or another player
- Change the GameOptionData for one player

Gameplay ideas :
- Give information during gameplay to a player by changing their name only to them
- When comms are sabotaged, all crewmate see everyone with the same color/skin and no name, but impostors are not affected
- Change the vision range of a player based on their completed task