### PR TITLE
Add proper Linux commands for Docs

### DIFF
--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -13,7 +13,7 @@ There are currently two modes to run the Impostor server in. The first way is th
 3. Download either the Windows or the Linux version.
 4. Extract the zip.
 5. Modify `config.json` to your liking. Documentation can be found [here](Server-configuration.md) *(this step is mandatory if you want to expose this server to other devices)*
-6. LINUX ONLY! Set permissions 755 to Impostor.Server / plugins / libraries with chmod 755 Impostor.Server plugins libraries. Set 644 to config.json with chmod 644 config.json
+6. LINUX ONLY! Set permissions 755 to Impostor.Server / plugins / libraries with `chmod 755 Impostor.Server plugins libraries`. Set 644 to config.json with `chmod 644 config.json`.
 7. Run `Impostor.Server.exe` (Windows) / `Impostor.Server` (Linux)
 
 ### Using docker

--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -13,8 +13,8 @@ There are currently two modes to run the Impostor server in. The first way is th
 3. Download either the Windows or the Linux version.
 4. Extract the zip.
 5. Modify `config.json` to your liking. Documentation can be found [here](Server-configuration.md) *(this step is mandatory if you want to expose this server to other devices)*
-5.1 LINUX ONLY! Set permissions 755 to Impostor.Server / plugins / libraries with chmod 755 Impostor.Server plugins libraries. Set 644 to config.json with chmod 644 config.json
-6. Run `Impostor.Server.exe` (Windows) / `Impostor.Server` (Linux)
+6. LINUX ONLY! Set permissions 755 to Impostor.Server / plugins / libraries with chmod 755 Impostor.Server plugins libraries. Set 644 to config.json with chmod 644 config.json
+7. Run `Impostor.Server.exe` (Windows) / `Impostor.Server` (Linux)
 
 ### Using docker
 

--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -14,7 +14,7 @@ There are currently two modes to run the Impostor server in. The first way is th
 4. Extract the zip.
 5. Modify `config.json` to your liking. Documentation can be found [here](Server-configuration.md) *(this step is mandatory if you want to expose this server to other devices)*
 6. LINUX ONLY! Set permissions 755 to Impostor.Server / plugins / libraries with `chmod 755 Impostor.Server plugins libraries`. Set 644 to config.json with `chmod 644 config.json`.
-7. Run `Impostor.Server.exe` (Windows) / `Impostor.Server` (Linux)
+7. Run `Impostor.Server.exe` (Windows) / `./Impostor.Server` (Linux)
 
 ### Using docker
 

--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -13,6 +13,7 @@ There are currently two modes to run the Impostor server in. The first way is th
 3. Download either the Windows or the Linux version.
 4. Extract the zip.
 5. Modify `config.json` to your liking. Documentation can be found [here](Server-configuration.md) *(this step is mandatory if you want to expose this server to other devices)*
+5.1 LINUX ONLY! Set permissions 755 to Impostor.Server / plugins / libraries with chmod 755 Impostor.Server plugins libraries. Set 644 to config.json with chmod 644 config.json
 6. Run `Impostor.Server.exe` (Windows) / `Impostor.Server` (Linux)
 
 ### Using docker


### PR DESCRIPTION
### Description

This PR will add proper commands to run Impostor server on linux.
You cannot just download the .zip, unzip it and run it. You must set permissions first.
Otherwise, you will just get errors from everywhere. Found out that these permissions hit the sweet spot for running Impostor on Debian/Ubuntu.
