### PR TITLE
Add security and versioning dependency alerts

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/IInnerMeetingHud.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerMeetingHud.cs
@@ -1,6 +1,6 @@
 ﻿namespace Impostor.Api.Net.Inner.Objects
 {
-    public interface IInnerMeetingHud
+    public interface IInnerMeetingHud : IInnerNetObject
     {
     }
 }

--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -24,6 +24,8 @@ namespace Impostor.Server.Plugins
             // Add the plugins and libraries.
             var pluginPaths = new List<string>(config.Paths);
             var libraryPaths = new List<string>(config.LibraryPaths);
+            CheckPaths(pluginPaths);
+            CheckPaths(libraryPaths);
 
             var rootFolder = Directory.GetCurrentDirectory();
 
@@ -118,6 +120,17 @@ namespace Impostor.Server.Plugins
             });
 
             return builder;
+        }
+
+        private static void CheckPaths(IEnumerable<string> paths)
+        {
+            foreach (var path in paths)
+            {
+                if (!Directory.Exists(path))
+                {
+                    Logger.Warning("Path {path} was specified in the PluginLoader configuration, but this folder doesn't exist!", path);
+                }
+            }
         }
 
         private static void RegisterAssemblies(


### PR DESCRIPTION
- add `dependabot.yml` which automatically enables Dependabot's dependency versioning scanner and dependency update PRs bot by declaring dependency ecosystems and sources in the project. For dependency security vulnerabilities scanner and vulnerable dependency update PRs bot, [enable "Dependabot alerts" and "Dependabot security updates"](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates)

Resolves #380 