### PR TITLE
Site: Add default regions to region file

### DIFF
--- a/script.js
+++ b/script.js
@@ -69,18 +69,46 @@ function setPlatform(platform) {
 }
 
 function generateRegionInfo(name, ip, fqdn, port) {
-    const region = {
-        "$type": "DnsRegionInfo, Assembly-CSharp",
-        "Fqdn": fqdn,
-        "DefaultIp": ip,
-        "Port": port,
-        "Name": name,
-        "TranslateName": 1003 // StringNames.NoTranslation
-    };
+    const regions = [
+        // Add default regions so they also show up in the menu
+        {
+            $type: "DnsRegionInfo, Assembly-CSharp",
+            Fqdn: "na.mm.among.us",
+            DefaultIp: "50.116.1.42",
+            Port: 22023,
+            Name: "North America",
+            TranslateName: 289,
+        },
+        {
+            $type: "DnsRegionInfo, Assembly-CSharp",
+            Fqdn: "eu.mm.among.us",
+            DefaultIp: "172.105.251.170",
+            Port: 22023,
+            Name: "Europe",
+            TranslateName: 290,
+        },
+        {
+            $type: "DnsRegionInfo, Assembly-CSharp",
+            Fqdn: "as.mm.among.us",
+            DefaultIp: "139.162.111.196",
+            Port: 22023,
+            Name: "Asia",
+            TranslateName: 291,
+        },
+        // Followed by the custom region
+        {
+            $type: "DnsRegionInfo, Assembly-CSharp",
+            Fqdn: fqdn,
+            DefaultIp: ip,
+            Port: port,
+            Name: name,
+            TranslateName: 1003, // StringNames.NoTranslation
+        },
+    ];
 
     const jsonServerData = {
-        "CurrentRegionIdx": 0,
-        "Regions": [region]
+        CurrentRegionIdx: 3,
+        Regions: regions,
     };
 
     return JSON.stringify(jsonServerData);


### PR DESCRIPTION
### Description
In the latest AU patch the menu is now generated based on this file. To
allow users to switch back to the default servers, add them to the file
as well.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- server list is empty except for the single custom server
