### PR TITLE
Fix KeyNotFoundException for nonexistent vents

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Impostor.Api.Events.Managers;
+using Impostor.Api.Innersloth;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Custom;
 using Impostor.Api.Net.Inner;
@@ -65,7 +66,15 @@ namespace Impostor.Server.Net.Inner.Objects.Components
                             throw new ArgumentOutOfRangeException(nameof(call), call, null);
                     }
 
-                    var vent = Game.GameNet.ShipStatus!.Data.Vents[ventId];
+                    if (!Game.GameNet.ShipStatus!.Data.Vents.TryGetValue(ventId, out var vent))
+                    {
+                        if (await sender.Client.ReportCheatAsync(call, "Client interacted with nonexistent vent"))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    }
 
                     switch (call)
                     {


### PR DESCRIPTION
### Description

Some mods allow players to create custom vents. Impostor does however not like it that people enter or exit a vent that has an ID that does not exist and throws a KeyNotFound exception. This commit changes that to throw an AntiCheatException instead.

A downside is that the Player{Enter,Exit}VentEvents are no longer called for these unknown vents, however this would require these events to allow the Vent to become nullable or the IVent to allow positions to be nullable, which is not a step I want to take at this moment.
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
