### PR TITLE
Site: Add support for deeplinking protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
                 <div class="mb-4 mb-md-3">
                     <h3 class="text-center text-md-left mb-4 mb-md-3 w-100">Connect to a Server</h3>
                 </div>
-                <form id="serverFileForm" class="container p-0" onsubmit="downloadAsync(); return false;">
+                <form id="serverFileForm" class="container p-0" onsubmit="return false;">
                     <div class="row justify-content-center mb-5 mb-md-4">
                         <div class="row justify-content-center flex-nowrap" style="max-width: 350px">
                             <input class="form-control form-control-lg bg-transparent text-light text-center mr-2"
@@ -40,7 +40,8 @@
                         </div>
                     </div>
                     <div class="row justify-content-center">
-                        <button class="btn btn-primary btn-lg">Download server file</button>
+                        <button class="btn btn-primary btn-lg support-text desktop-support" onclick="downloadAsync()">Download Server File</button>
+                        <button class="btn btn-primary btn-lg support-text android-support ios-support" onclick="openApp()">Open in Among Us</button>
                     </div>
                 </form>
                 <div class="mt-4">
@@ -67,24 +68,10 @@
                             <li>You can now play on your server by opening Among Us and clicking "Online".</li>
                         </ol>
                         To switch back to the original servers, change the region in the bottom right corner.<br/>
-                        If you want to switch back to your server, re-do the steps above.
                     </div>
 
-                    <div class="support-text ios-support">
-                        <p class="text-justify text-sm-center text-md-left">There are two methods to play on a private server on iOS, both of which require a <a href="https://canijailbreak.com">jailbreak</a>.</p>
-                        <h4 class="text-md-left mb-4 mb-md-3 w-100">1. Jailbreak tweak</h4>
-                        <p class="text-justify text-md-left">
-                            You can install the ImpostorConfig tweak from pixelomer's repo on your jailbroken device.
-                            <a href="cydia://url/https://cydia.saurik.com/api/share#?source=https://repo.pixelomer.com">Add to Cydia</a>
-                        </p>
-                        <div class="mt-4">
-                            <h4 class="text-md-left mb-4 mb-md-3 w-100">2. Manual method</h4>
-                            <p class="text-justify text-sm-center text-md-left">Type the server IP and overwrite the <b>regionInfo.json</b> file in <b>/var/mobile/Containers/Data/Application/Among Us/Documents</b> using Filza.</p>
-                        </div>
-                    </div>
-
-                    <div class="support-text android-support">
-                        <p class="text-justify text-sm-center text-md-left">To play on a private server, type the server IP and overwrite the <b>regionInfo.json</b> file in <b>Internal Storage/Android/data/com.innersloth.spacemafia/files</b>.</p>
+                    <div class="support-text android-support ios-support">
+                        <p class="text-justify text-sm-center text-md-left">To play on a private server, fill in the form, then click "Open in Among Us". You can then switch to your server using the Region Selection menu in the bottom right corner.</p>
                     </div>
                 </div>
             </section>

--- a/index.html
+++ b/index.html
@@ -71,7 +71,10 @@
                     </div>
 
                     <div class="support-text android-support ios-support">
-                        <p class="text-justify text-sm-center text-md-left">To play on a private server, fill in the form, then click "Open in Among Us". You can then switch to your server using the Region Selection menu in the bottom right corner.</p>
+                        <p class="text-justify text-sm-center text-md-left">
+                            To play on a private server, fill in the form, then click "Open in Among Us". You can then switch to your server using the Region Selection menu in the bottom right corner.<br/>
+                            You may get a confirmation prompt from your browser to confirm that you want to open Among Us, which you should accept.
+                        </p>
                     </div>
                 </div>
             </section>

--- a/script.js
+++ b/script.js
@@ -58,7 +58,7 @@ async function downloadAsync() {
 }
 
 async function openApp() {
-    const [serverAddress, serverPort, serverName] = parseForm();
+    const [serveraddress, serverport, servername] = parseForm();
     const [serverip, _] = await parseAddressAsync(serveraddress);
 
     const params = new URLSearchParams({

--- a/script.js
+++ b/script.js
@@ -67,7 +67,7 @@ async function openApp() {
         serverip,
     });
     const url = `amongus://init?${params.toString()}`;
-    window.open(url, "_blank");
+    window.location = url;
 
     return false;
 }

--- a/script.js
+++ b/script.js
@@ -33,15 +33,41 @@ async function parseAddressAsync(serverAddress) {
     throw Error(message);
 }
 
-async function downloadAsync() {
+function parseForm() {
     const serverAddress = document.getElementById("address").value;
     const serverPort = document.getElementById("port").value ?? DEFAULT_PORT;
     const serverName = document.getElementById("name").value || "Impostor";
 
+    return [serverAddress, serverPort, serverName];
+}
+
+async function downloadAsync() {
+    const [serverAddress, serverPort, serverName] = parseForm();
     const [serverIp, serverFqdn] = await parseAddressAsync(serverAddress);
-    const json = generateRegionInfo(serverName, serverIp, serverFqdn, serverPort);
-    const blob = new Blob([json], {type: "text/plain"});
+
+    const json = generateRegionInfo(
+        serverName,
+        serverIp,
+        serverFqdn,
+        serverPort
+    );
+    const blob = new Blob([json], { type: "text/plain" });
     saveFile(blob, "regionInfo.json");
+
+    return false;
+}
+
+async function openApp() {
+    const [serverAddress, serverPort, serverName] = parseForm();
+    const [serverip, _] = await parseAddressAsync(serveraddress);
+
+    const params = new URLSearchParams({
+        servername,
+        serverport,
+        serverip,
+    });
+    const url = `amongus://init?${params.toString()}`;
+    window.open(url, "_blank");
 
     return false;
 }
@@ -49,7 +75,9 @@ async function downloadAsync() {
 let currentPlatform;
 
 function setEnabled(platform, value) {
-    document.querySelector(`.${platform}-support`).style.display = value ? "block" : "none";
+    for (const e of document.querySelectorAll(`.${platform}-support`)) {
+        e.style.display = value ? "block" : "none";
+    }
 }
 
 function setPlatform(platform) {

--- a/style.css
+++ b/style.css
@@ -48,7 +48,6 @@ select.form-control option {
 
 .support-text {
     display: none;
-    word-break: break-all;
 }
 
 .key {


### PR DESCRIPTION
### Description

This can be used on both iPhone and Android to add a StaticRegion to the
game. As this does not involve either a jailbreak or fiddling with
files, this replaces the previous ios/android instructions.

I deployed a copy to https://duikbo.at/impostor-region-generator/pr414/ so you can test it easily yourself on a phone

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- addresses the inability to join impostor servers on iOS without jailbreaking
