### PR TITLE
Initialize Color to -1 instead of Red

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -21,7 +21,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public string PlayerName { get; internal set; } = string.Empty;
 
-        public ColorType Color { get; internal set; }
+        public ColorType Color { get; internal set; } = (ColorType)(-1);
 
         public HatType Hat { get; internal set; }
 


### PR DESCRIPTION
This could lead to an AC disconnect if the host picked red and waited
for other players to rejoin before joining back himself. Before this
commit, the host would SetColor himself to Red, but this would be
flagged as all other players would have been set to Red as enums
initialize to 0 (= Red) by default.

After the host SetColor'd himself, the host will send over the color
array, which initializes player colors to -1. This commit follows AU by
also initializing the color to -1, preventing the AC from flagging the
duplicate colors.