### PR TITLE
Add two extra rules that warn for explicit types and unused usings

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -147,6 +147,9 @@ dotnet_diagnostic.RS2008.severity = none
 # IDE0005: Remove unnecessary import
 dotnet_diagnostic.IDE0005.severity = warning
 
+# IDE0007: Use `var` instead of explicit type
+dotnet_diagnostic.IDE0007.severity = warning
+
 # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0035.severity = warning
 

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -144,6 +144,9 @@ dotnet_naming_style.end_in_async.word_separator =
 # error RS2008: Enable analyzer release tracking for the analyzer project containing rule '{0}'
 dotnet_diagnostic.RS2008.severity = none
 
+# IDE0005: Remove unnecessary import
+dotnet_diagnostic.IDE0005.severity = warning
+
 # IDE0035: Remove unreachable code
 dotnet_diagnostic.IDE0035.severity = warning
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <VersionPrefix>1.5.0</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
+    <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Impostor.Benchmarks/Data/MessageReader_Bytes_Pooled.cs
+++ b/src/Impostor.Benchmarks/Data/MessageReader_Bytes_Pooled.cs
@@ -9,7 +9,7 @@ namespace Impostor.Benchmarks.Data
 {
     public class MessageReader_Bytes_Pooled
     {
-        private static ConcurrentQueue<MessageReader_Bytes_Pooled> _readers;
+        private static readonly ConcurrentQueue<MessageReader_Bytes_Pooled> _readers;
 
         static MessageReader_Bytes_Pooled()
         {

--- a/src/Impostor.Benchmarks/Data/MessageWriter.cs
+++ b/src/Impostor.Benchmarks/Data/MessageWriter.cs
@@ -11,7 +11,7 @@ namespace Impostor.Benchmarks.Data
     {
         public MessageType SendOption { get; private set; }
 
-        private Stack<int> messageStarts = new Stack<int>();
+        private readonly Stack<int> _messageStarts = new Stack<int>();
 
         public MessageWriter(byte[] buffer)
         {
@@ -78,7 +78,7 @@ namespace Impostor.Benchmarks.Data
         ///
         public void StartMessage(byte typeFlag)
         {
-            messageStarts.Push(this.Position);
+            _messageStarts.Push(this.Position);
             this.Position += 2; // Skip for size
             this.Write(typeFlag);
         }
@@ -86,7 +86,7 @@ namespace Impostor.Benchmarks.Data
         ///
         public void EndMessage()
         {
-            var lastMessageStart = messageStarts.Pop();
+            var lastMessageStart = _messageStarts.Pop();
             var length = (ushort)(this.Position - lastMessageStart - 3); // Minus length and type byte
             this.Buffer[lastMessageStart] = (byte)length;
             this.Buffer[lastMessageStart + 1] = (byte)(length >> 8);
@@ -95,13 +95,13 @@ namespace Impostor.Benchmarks.Data
         ///
         public void CancelMessage()
         {
-            this.Position = this.messageStarts.Pop();
+            this.Position = this._messageStarts.Pop();
             this.Length = this.Position;
         }
 
         public void Clear(MessageType sendOption)
         {
-            this.messageStarts.Clear();
+            this._messageStarts.Clear();
             this.SendOption = sendOption;
             this.Buffer[0] = (byte)sendOption;
             switch (sendOption)
@@ -293,7 +293,7 @@ namespace Impostor.Benchmarks.Data
             this.Write(msg.Buffer, offset, msg.Length - offset);
         }
 
-        public unsafe static bool IsLittleEndian()
+        public static unsafe bool IsLittleEndian()
         {
             byte b;
             unsafe

--- a/src/Impostor.Server/Net/AnnouncementsService.cs
+++ b/src/Impostor.Server/Net/AnnouncementsService.cs
@@ -4,7 +4,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Impostor.Api.Events.Managers;
-using Impostor.Api.Innersloth;
 using Impostor.Api.Net.Messages;
 using Impostor.Api.Net.Messages.Announcements;
 using Impostor.Hazel;

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Impostor.Api.Events.Managers;
-using Impostor.Api.Innersloth;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Custom;
 using Impostor.Api.Net.Inner;

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Impostor.Api;
 using Impostor.Api.Events.Managers;
-using Impostor.Api.Innersloth.Maps;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Custom;
 using Impostor.Api.Net.Inner;

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -427,7 +427,7 @@ namespace Impostor.Server.Net.Inner.Objects
                     var i = 1;
                     while (true)
                     {
-                        string text = expected + " " + i;
+                        var text = expected + " " + i;
 
                         if (Game.Players.All(x => x.Character == null || x.Character == this || x.Character.PlayerInfo.PlayerName != text))
                         {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using Impostor.Api.Events.Managers;
 using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Innersloth.Customization;
 using Impostor.Api.Net.Messages;
 using Impostor.Api.Utils;
-using Impostor.Server.Net.State;
 
 namespace Impostor.Server.Net.Inner.Objects
 {


### PR DESCRIPTION
### Description

This fits in with the style currently used in Impostor and as a result should be enforced.

To preempt the question of why this isn't in `Directory.Build.props`: that'd also apply these rules to Hazel, which is 3rd party code and therefore shouldn't be affected by our rules.
