### PR TITLE
Fix mismatched hats

### DIFF
--- a/src/Impostor.Api/Innersloth/Customization/HatType.cs
+++ b/src/Impostor.Api/Innersloth/Customization/HatType.cs
@@ -1,4 +1,4 @@
-﻿namespace Impostor.Api.Innersloth.Customization
+namespace Impostor.Api.Innersloth.Customization
 {
     public enum HatType : uint
     {
@@ -109,13 +109,13 @@
         ToppatHenry = 104,
         ToppatEllie = 105,
         GeoffreyPlumb = 106,
-        AngryEyebrows = 107,
-        ChocolateIce = 108,
-        HeartPin = 109,
-        Ponytail = 110,
-        RubberGlove = 111,
-        UnicornHorn = 112,
-        Zipper = 113,
-        RightHandMan = 114,
+        RightHandMan = 107,
+        AngryEyebrows = 108,
+        ChocolateIce = 109,
+        HeartPin = 110,
+        Ponytail = 111,
+        RubberGlove = 112,
+        UnicornHorn = 113,
+        Zipper = 114,
     }
 }


### PR DESCRIPTION
### Description


Hat names in this enum did not match the hat displayed in the Among Us client for indices >= 107.
Inserting RightHandMan at 107 and increasing all following indices by 1 fixes this.