### PR TITLE
Improve error when client version is unsupported

### DIFF
--- a/src/Impostor.Server/Config/DisconnectMessages.cs
+++ b/src/Impostor.Server/Config/DisconnectMessages.cs
@@ -4,7 +4,7 @@
     {
         public const string Error = "There was an internal server error. " +
                                     "Check the server console for more information. " +
-                                    "Please report the issue on the AmongUsServer GitHub if it keeps happening.";
+                                    "Please report the issue on the Impostor GitHub if it keeps happening.";
 
         public const string Destroyed = "The game you tried to join is being destroyed. " +
                                         "Please create a new game.";
@@ -15,5 +15,11 @@
         public const string UsernameLength = "Your username is too long, please make it shorter.";
 
         public const string UsernameIllegalCharacters = "Your username contains illegal characters, please remove them.";
+
+        public const string VersionClientTooOld = "Please update your game to play on this server.";
+
+        public const string VersionServerTooOld = "Your client is too new, please update your Impostor server to play.";
+
+        public const string VersionUnsupported = "Your client version is unsupported, please update your Game and/or Impostor server.";
     }
 }


### PR DESCRIPTION
### Description

In the default message that was used previously the user is asked to
upgrade his game. This is not always correct, as sometimes the Impostor
server is too old and should be updated instead. Therefore custom
disconnect messages are used that blames either the user or the server
operator, which is hopefully more accurate.

I've chosen not to include the game version that is supported by the
server in this message because the network version rarely matches the
advertised version in the main menu.

### Closes issues

- prevents many issues of people trying to set up Impostor for the first time and downloading the wrong version
