### PR TITLE
Update site to AU 2021.12.14

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
                             NOTE: This currently doesn't work on version 2021.12.15a. You can either download the server file and overwrite the existing regionInfo.json file in <code>Internal Storage/Android/data/com.innersloth.spacemafia/files</code>. Alternatively, downgrade to 6.30 and press the Open in App option, then this should work fine.
                         </p>
                         <p class="text-justify text-sm-center text-md-left ios-support" style="display: none;">
-                            NOTE: This currently doesn't work on version 2021.12.15o. If your phone is jailbreaked, you can install the <a href="cydia://url/https://cydia.saurik.com/api/share#?source=https://repo.pixelomer.com">ImpostorConfig tweak from pixelomer's repo</a> or download the regionInfo.json file and copy it to <code>/var/mobile/Containers/Data/Application/Among Us/Documents</code> using Filza.
+                            NOTE: This currently doesn't work on version 2021.12.15o. If your phone has been jailbroken, you can install the <a href="cydia://url/https://cydia.saurik.com/api/share#?source=https://repo.pixelomer.com">ImpostorConfig tweak from pixelomer's repo</a> or download the regionInfo.json file and copy it to <code>/var/mobile/Containers/Data/Application/Among Us/Documents</code> using Filza.
                         </p>
                         <p class="text-justify text-sm-center text-md-left">
                             To play on a private server, fill in the form, then click "Open in Among Us". You can then switch to your server using the Region Selection menu in the bottom right corner.<br/>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                         </div>
                     </div>
                     <div class="row justify-content-center">
-                        <button class="btn btn-primary btn-lg support-text desktop-support" onclick="downloadAsync()">Download Server File</button>
+                        <button class="btn btn-primary btn-lg support-text desktop-support android-support ios-support" onclick="downloadAsync()">Download Server File</button>
                         <button class="btn btn-primary btn-lg support-text android-support ios-support" onclick="openApp()">Open in Among Us</button>
                     </div>
                 </form>
@@ -71,6 +71,12 @@
                     </div>
 
                     <div class="support-text android-support ios-support">
+                        <p class="text-justify text-sm-center text-md-left android-support" style="display: none;">
+                            NOTE: This currently doesn't work on version 2021.12.15a. You can either download the server file and overwrite the existing regionInfo.json file in <code>Internal Storage/Android/data/com.innersloth.spacemafia/files</code>. Alternatively, downgrade to 6.30 and press the Open in App option, then this should work fine.
+                        </p>
+                        <p class="text-justify text-sm-center text-md-left ios-support" style="display: none;">
+                            NOTE: This currently doesn't work on version 2021.12.15o. If your phone is jailbreaked, you can install the <a href="cydia://url/https://cydia.saurik.com/api/share#?source=https://repo.pixelomer.com">ImpostorConfig tweak from pixelomer's repo</a> or download the regionInfo.json file and copy it to <code>/var/mobile/Containers/Data/Application/Among Us/Documents</code> using Filza.
+                        </p>
                         <p class="text-justify text-sm-center text-md-left">
                             To play on a private server, fill in the form, then click "Open in Among Us". You can then switch to your server using the Region Selection menu in the bottom right corner.<br/>
                             You may get a confirmation prompt from your browser to confirm that you want to open Among Us, which you should accept.

--- a/script.js
+++ b/script.js
@@ -106,6 +106,7 @@ function generateRegionInfo(name, ip, fqdn, port) {
             Port: 22023,
             Name: "North America",
             TranslateName: 289,
+            UseDtls: true,
         },
         {
             $type: "DnsRegionInfo, Assembly-CSharp",
@@ -114,6 +115,7 @@ function generateRegionInfo(name, ip, fqdn, port) {
             Port: 22023,
             Name: "Europe",
             TranslateName: 290,
+            UseDtls: true,
         },
         {
             $type: "DnsRegionInfo, Assembly-CSharp",
@@ -122,6 +124,7 @@ function generateRegionInfo(name, ip, fqdn, port) {
             Port: 22023,
             Name: "Asia",
             TranslateName: 291,
+            UseDtls: true,
         },
         // Followed by the custom region
         {
@@ -131,6 +134,7 @@ function generateRegionInfo(name, ip, fqdn, port) {
             Port: port,
             Name: name,
             TranslateName: 1003, // StringNames.NoTranslation
+            UseDtls: false, // As no custom key can be specified, we need to disable DTLS on custom servers.
         },
     ];
 

--- a/script.js
+++ b/script.js
@@ -35,7 +35,7 @@ async function parseAddressAsync(serverAddress) {
 
 function parseForm() {
     const serverAddress = document.getElementById("address").value;
-    const serverPort = document.getElementById("port").value ?? DEFAULT_PORT;
+    const serverPort = parseInt(document.getElementById("port").value) ?? DEFAULT_PORT;
     const serverName = document.getElementById("name").value || "Impostor";
 
     return [serverAddress, serverPort, serverName];


### PR DESCRIPTION
### Description

AU 2021.11.9 added mandatory DTLS support. AU 2021.12.14 allows you to
disable this, but needs a special key in the regionInfo.json file for that.

AU 2021.12.14 forces the value of the new UseDtls value to true, this
makes the deeplink protocol unusable on this version.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
