### PR TITLE
Fix/host migrate

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -354,6 +354,11 @@ namespace Impostor.Server.Net.Inner.Objects
                     Rpc44SetRole.Deserialize(reader, out var role);
                     PlayerInfo.RoleType = role;
 
+                    if (Game.GameState == GameStates.Starting)
+                    {
+                        await Game.StartedAsync();
+                    }
+
                     break;
                 }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -85,9 +85,9 @@ namespace Impostor.Server.Net.Inner.Objects
 
             var taskCount = reader.ReadByte();
 
-            if (Tasks.Count != taskCount)
+            if (Tasks.Count < taskCount)
             {
-                Tasks = new List<InnerGameData.TaskInfo>(taskCount);
+                taskCount = (byte)Tasks.Count;
             }
 
             for (var i = 0; i < taskCount; i++)

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -383,6 +383,7 @@ namespace Impostor.Server.Net.State
                 case InnerPlayerControl control:
                 {
                     if (GameState != GameStates.Started)
+                    if (GameState != GameStates.Started && GameState != GameStates.Starting)
                     {
                         GameNet.GameData?.RemovePlayer(control);
                     }


### PR DESCRIPTION
### Description

In the current development version of Impostor, when the host of a game disconnects, the InnerPlayerInfo from the player is removed, which causes the new host to disconnect because of a deserialization error.

- Commit 1 fixes the detection of the game start: when the first SetRole RPC is sent, the game is considered to have started, preventing the bug from occurring.
- Commit 2 does not destroy InnerPlayerInfo objects when the game is starting, preventing the bug from occurring while the game is starting.
- Commit 3 does not attempts to access tasks that are out of bounds. New tasks cannot be created at this point because we don't know the underlying task. This fixes the root cause of the bug

Either of these commits on its own is enough to stop the mass disconnect from happening.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
