### PR TITLE
AC CheckMurder: Require half of cooldown

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -55,6 +55,11 @@ namespace Impostor.Server.Net.Inner.Objects
                 return false;
             }
 
+            // In 2021.11.9 the Guardian Angel was created, which was unfortunately implemented in such a way that
+            // it is hard to determine accurately whether a kill was prevented or not. When a kill was prevented,
+            // the impostor has a cooldown of half the usual duration. As a workaround we always assume the kill was
+            // prevented and the impostor only has half of its cooldown.
+            // FIXME when the base game improved their implementation.
             return dateTimeProvider.UtcNow.Subtract(LastMurder).TotalSeconds >= game.Options.KillCooldown / 2;
         }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -55,7 +55,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 return false;
             }
 
-            return dateTimeProvider.UtcNow.Subtract(LastMurder).TotalSeconds >= game.Options.KillCooldown;
+            return dateTimeProvider.UtcNow.Subtract(LastMurder).TotalSeconds >= game.Options.KillCooldown / 2;
         }
 
         public void Serialize(IMessageWriter writer)


### PR DESCRIPTION
### Description

When the Guardian Angel protects a player, the impostor that just missed
their kill gets back half of their cooldown. Keeping track of whether or
not the player was protected is more difficult due to how the Guardian
Angel is implemented, so instead we halve the minimum time between kill
in order to minimize false positives.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
