### PR TITLE
Fix/i18n nicknames

### DIFF
--- a/src/Impostor.Api/Innersloth/TextBox.cs
+++ b/src/Impostor.Api/Innersloth/TextBox.cs
@@ -4,7 +4,19 @@
     {
         public static bool IsCharAllowed(char i)
         {
-            return i == ' ' || (i >= 'A' && i <= 'Z') || (i >= 'a' && i <= 'z') || (i >= '0' && i <= '9') || (i >= 'À' && i <= 'ÿ') || (i >= 'Ѐ' && i <= 'џ') || (i >= 'ㄱ' && i <= 'ㆎ') || (i >= '가' && i <= '힣');
+            return i == ' ' ||
+                (i >= 'A' && i <= 'Z') ||
+                (i >= 'a' && i <= 'z') ||
+                (i >= '0' && i <= '9') ||
+
+                // U+00C0 to U+00FF (Latin-1 Supplement)
+                (i >= 'À' && i <= 'ÿ') ||
+
+                // U+0400 to U+045F (Cyrillic)
+                (i >= 'Ѐ' && i <= 'џ') ||
+
+                // U+2C61 to U+D7A3 (CJK)
+                (i >= 'ⱡ' && i <= '힣');
         }
     }
 }

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -90,15 +90,7 @@ namespace Impostor.Server.Net.Manager
                 return;
             }
 
-            if (name.Length > 10)
-            {
-                using var packet = MessageWriter.Get(MessageType.Reliable);
-                Message01JoinGameS2C.SerializeError(packet, false, DisconnectReason.Custom, DisconnectMessages.UsernameLength);
-                await connection.SendAsync(packet);
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(name) || !name.All(TextBox.IsCharAllowed))
+            if (string.IsNullOrWhiteSpace(name))
             {
                 using var packet = MessageWriter.Get(MessageType.Reliable);
                 Message01JoinGameS2C.SerializeError(packet, false, DisconnectReason.Custom, DisconnectMessages.UsernameIllegalCharacters);

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -90,6 +90,14 @@ namespace Impostor.Server.Net.Manager
                 return;
             }
 
+            if (name.Length > 10)
+            {
+                using var packet = MessageWriter.Get(MessageType.Reliable);
+                Message01JoinGameS2C.SerializeError(packet, false, DisconnectReason.Custom, DisconnectMessages.UsernameLength);
+                await connection.SendAsync(packet);
+                return;
+            }
+
             if (string.IsNullOrWhiteSpace(name))
             {
                 using var packet = MessageWriter.Get(MessageType.Reliable);


### PR DESCRIPTION
### Description

Somewhere this year, Innersloth allowed more characters to be used in the nickname field. This commit (finally) adopts Impostor to deal with this new reality.

Commit 1 updates the allowlist of characters
Commit 2 makes checking the validity of the nickname the responsibility of the anticheat instead of the server.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #403 (sorry for taking so long :< )
- closes #447 (this PR is more extensive)
- closes #448
