### PR TITLE
AC: Allow engineers to move to a different vent.

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
@@ -120,7 +120,7 @@ namespace Impostor.Server.Net.Inner.Objects.Components
                     }
                 }
 
-                if (!await ValidateImpostor(call, sender, _playerControl.PlayerInfo))
+                if (!await ValidateCanVent(call, sender, _playerControl.PlayerInfo))
                 {
                     return false;
                 }


### PR DESCRIPTION
### Description

SnapTo is called when players move to a different vent. This was not adapted to the Engineer yet.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #457 
