### PR TITLE
Do not broadcast messages to disconnected clients

### DIFF
--- a/src/Impostor.Server/Net/State/Game.cs
+++ b/src/Impostor.Server/Net/State/Game.cs
@@ -123,7 +123,8 @@ namespace Impostor.Server.Net.State
         {
             return Players
                 .Where(filter)
-                .Select(p => p.Client.Connection)!;
+                .Select(p => p.Client.Connection)
+                .Where(c => c != null && c.IsConnected)!;
         }
     }
 }


### PR DESCRIPTION
### Description

This method is used when players have disconnected. If multiple players
disconnect at once, this method leads to exceptions.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
