### PR TITLE
Add Serilog.Settings.Configuration

### DIFF
--- a/docs/Server-configuration.md
+++ b/docs/Server-configuration.md
@@ -53,7 +53,7 @@ The Debug configuration is used to enable the game recorder. This is mostly usef
 | Key                     | Default | Value                                        |
 | ----------------------- | ------- | -------------------------------------------- |
 | **GameRecorderEnabled** | `false` | Enables the Game Recorder.                   |
-| **GameRecorderPath**    | *empty* | Path where the recorded games will be saved. |
+| **GameRecorderPath**    | _empty_ | Path where the recorded games will be saved. |
 
 ### ServerRedirector
 
@@ -70,7 +70,15 @@ In a multi-node setup these values need to be specified. Note that most people d
 
 ### Serilog (Logging)
 
-If the standard logging via the console is not enough, it is possible to configure the logging framework Serilog to add additional sinks.
+Impostor's log framework, Serilog, can be configured in the config file. You can change its default log level and you can add additional sinks.
+
+| Key              | Default       | Value                                                                                                                                                                                                                          |
+| ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **MinimumLevel** | `Information` | Minimum log level for a message to be printed. If a log entry is as severe or more severe than this level, it will be printed. From most severe to least severe: `Fatal`,`Error`, `Warning`, `Information`, `Debug`, `Verbose` |
+| **Using**        | `[]`          | List of additional Serilog Sinks assemblies to load.                                                                                                                                                                           |
+| **WriteTo**      | `[]`          | Additional logging sinks. See the Serilog documentation or the example in this section. Serilog                                                                                                                                |
+
+For more information, check the [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration) documentation.
 
 For example, to add logging to a file, you should add the following snippet to your configuration:
 

--- a/docs/Server-configuration.md
+++ b/docs/Server-configuration.md
@@ -68,6 +68,33 @@ In a multi-node setup these values need to be specified. Note that most people d
 | **>UdpMasterEndpoint** |         | On the master, this value acts as a listen ip and port. On a node, this should be the public ip and port of the master. Format `127.0.0.1:32320`. |
 | **Nodes**              |         | An array containing public ips and ports of nodes. Only needs to be set on the master. See above for an example.                                  |
 
+### Serilog (Logging)
+
+If the standard logging via the console is not enough, it is possible to configure the logging framework Serilog to add additional sinks.
+
+For example, to add logging to a file, you should add the following snippet to your configuration:
+
+```json
+"Serilog": {
+  "Using": [
+    "Serilog.Sinks.File"
+  ],
+  "WriteTo": [
+    {
+      "Name": "File",
+      "Args": {
+        "path": "logs/log.txt",
+        "rollingInterval": "Day"
+      }
+    }
+  ]
+}
+```
+
+Next to that, you also need to copy over Serilog.Sinks.File.dll from [NuGet](https://www.nuget.org/packages/Serilog.Sinks.File/). See the [Serilog.Sinks.File documentation](https://github.com/serilog/serilog-sinks-file#json-appsettingsjson-configuration) for a list of parameters that can be configured.
+
+Other Serilog sinks are also supported, but are out of scope for this documentation.
+
 ## Config providers
 
 ### File

--- a/src/Impostor.Server/Impostor.Server.csproj
+++ b/src/Impostor.Server/Impostor.Server.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.5" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Closes #409

Minimum log level can be now set in config by adding
```json
"Serilog": {
	"MinimumLevel": "Warning"
}
```

This also allows for using different sinks like `Serilog.Sinks.File`
```json
"Serilog": {
  "Using": [
    "Serilog.Sinks.File"
  ],
  "WriteTo": [
    {
      "Name": "File",
      "Args": {
        "path": "logs/log.txt",
        "rollingInterval": "Day"
      }
    }
  ]
}
```
^ requires `Serilog.Sinks.File.dll` from [nuget](https://www.nuget.org/packages/Serilog.Sinks.File/) to be copied into the same  directory as Impostor.Server binary