### PR TITLE
Add handling for null ShipStatus

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/ITaskInfo.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/ITaskInfo.cs
@@ -7,7 +7,7 @@ namespace Impostor.Api.Net.Inner.Objects
     {
         uint Id { get; }
 
-        ITask Task { get; }
+        ITask? Task { get; }
 
         bool Complete { get; }
 

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerCustomNetworkTransform.cs
@@ -125,20 +125,31 @@ namespace Impostor.Server.Net.Inner.Objects.Components
                     return false;
                 }
 
-                var vents = Game.GameNet.ShipStatus!.Data.Vents.Values;
-
-                var vent = vents.SingleOrDefault(x => Approximately(x.Position, position + ColliderOffset));
-
-                if (vent == null)
+                if (Game.GameNet.ShipStatus == null)
                 {
-                    if (await sender.Client.ReportCheatAsync(call, "Failed vent position check"))
+                    // Cannot perform vent position check on unknown ship statuses
+                    if (await sender.Client.ReportCheatAsync(call, "Failed vent position check on unknown map"))
                     {
                         return false;
                     }
                 }
                 else
                 {
-                    await _eventManager.CallAsync(new PlayerVentEvent(Game, sender, _playerControl, vent));
+                    var vents = Game.GameNet.ShipStatus!.Data.Vents.Values;
+
+                    var vent = vents.SingleOrDefault(x => Approximately(x.Position, position + ColliderOffset));
+
+                    if (vent == null)
+                    {
+                        if (await sender.Client.ReportCheatAsync(call, "Failed vent position check"))
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        await _eventManager.CallAsync(new PlayerVentEvent(Game, sender, _playerControl, vent));
+                    }
                 }
 
                 await SnapToAsync(sender, position, minSid);

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -66,6 +66,16 @@ namespace Impostor.Server.Net.Inner.Objects.Components
                             throw new ArgumentOutOfRangeException(nameof(call), call, null);
                     }
 
+                    if (Game.GameNet.ShipStatus == null)
+                    {
+                        if (await sender.Client.ReportCheatAsync(call, "Client interacted with vent on unknown map"))
+                        {
+                            return false;
+                        }
+
+                        break;
+                    }
+
                     if (!Game.GameNet.ShipStatus!.Data.Vents.TryGetValue(ventId, out var vent))
                     {
                         if (await sender.Client.ReportCheatAsync(call, "Client interacted with nonexistent vent"))

--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -76,7 +76,7 @@ namespace Impostor.Server.Net.Inner.Objects.Components
                         break;
                     }
 
-                    if (!Game.GameNet.ShipStatus!.Data.Vents.TryGetValue(ventId, out var vent))
+                    if (!Game.GameNet.ShipStatus.Data.Vents.TryGetValue(ventId, out var vent))
                     {
                         if (await sender.Client.ReportCheatAsync(call, "Client interacted with nonexistent vent"))
                         {

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.TaskInfo.cs
@@ -12,7 +12,7 @@ namespace Impostor.Server.Net.Inner.Objects
             private readonly InnerPlayerInfo _playerInfo;
             private readonly IEventManager _eventManager;
 
-            public TaskInfo(InnerPlayerInfo playerInfo, IEventManager eventManager, uint id, ITask task)
+            public TaskInfo(InnerPlayerInfo playerInfo, IEventManager eventManager, uint id, ITask? task)
             {
                 _playerInfo = playerInfo;
                 _eventManager = eventManager;
@@ -22,7 +22,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
             public uint Id { get; internal set; }
 
-            public ITask Task { get; internal set; }
+            public ITask? Task { get; internal set; }
 
             public bool Complete { get; internal set; }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -144,7 +144,7 @@ namespace Impostor.Server.Net.Inner.Objects
                     player,
                     _eventManager,
                     taskId++,
-                    Game.GameNet!.ShipStatus!.Data.Tasks[taskTypeId]
+                    Game.GameNet!.ShipStatus?.Data.Tasks[taskTypeId]
                 ));
             }
         }

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -187,7 +187,7 @@ namespace Impostor.Server.Net.State
                             continue;
                         }
 
-                        _logger.LogError("Couldn't find spawnable object {0}.", objectId);
+                        _logger.LogWarning("Couldn't find spawnable object {0}.", objectId);
                         break;
                     }
 

--- a/src/Impostor.Server/Net/State/Game.cs
+++ b/src/Impostor.Server/Net/State/Game.cs
@@ -103,7 +103,11 @@ namespace Impostor.Server.Net.State
                 foreach (var player in _players.Values)
                 {
                     player.Character?.NetworkTransform.OnPlayerSpawn();
-                    await player.Character!.NetworkTransform.SetPositionAsync(player, GameNet.ShipStatus!.GetSpawnLocation(player.Character, PlayerCount, true), Vector2.Zero);
+
+                    if (GameNet.ShipStatus != null)
+                    {
+                        await player.Character!.NetworkTransform.SetPositionAsync(player, GameNet.ShipStatus.GetSpawnLocation(player.Character, PlayerCount, true), Vector2.Zero);
+                    }
                 }
 
                 GameState = GameStates.Started;


### PR DESCRIPTION
### Description

This pull request fixes disconnections caused by a null ShipStatus.

#### With a null ShipStatus:
- If a player tries to enter, exit, or move between vents, they are disconnected for cheating instead of causing an exception
- When assigning tasks, the server will now assign a null ITask on each TaskInfo object instead of causing an exception
- The server will abstain from spawning players in, instead of causing an exception

I've also changed the log level for the unknown spawnable log from error to warning. 