### PR TITLE
Allow adding custom tasks on standard maps

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -140,12 +140,9 @@ namespace Impostor.Server.Net.Inner.Objects
             var taskId = 0u;
             foreach (var taskTypeId in taskTypeIds.Span)
             {
-                player.Tasks.Add(new TaskInfo(
-                    player,
-                    _eventManager,
-                    taskId++,
-                    Game.GameNet!.ShipStatus?.Data.Tasks[taskTypeId]
-                ));
+                var mapTasks = Game.GameNet!.ShipStatus?.Data.Tasks;
+                var taskType = mapTasks?.ContainsKey(taskTypeId) ?? false ? mapTasks[taskTypeId] : null;
+                player.Tasks.Add(new TaskInfo(player, _eventManager, taskId++, taskType));
             }
         }
     }


### PR DESCRIPTION
### Description

This is needed for mods that add tasks to standard maps, but also mods
that add custom maps: because their custom netobjects don't get
registered Impostor thinks people are still on the old map when people
switch to the custom map after playing a game.
