### PR TITLE
Add Chat Language to game listings

### DIFF
--- a/src/Impostor.Api/Net/Messages/S2C/Message16GetGameListS2C.cs
+++ b/src/Impostor.Api/Net/Messages/S2C/Message16GetGameListS2C.cs
@@ -28,6 +28,7 @@ namespace Impostor.Api.Net.Messages.S2C
                 var platform = game.Host?.Client.PlatformSpecificData;
                 writer.Write((byte)(platform?.Platform ?? 0));
                 writer.Write(platform?.PlatformName ?? string.Empty);
+                writer.Write((uint)game.Options.Keywords);
                 writer.EndMessage();
             }
 


### PR DESCRIPTION
This was added to the in 6.23 patch

Note that this breaks lobby listing support in 3.29 and older, but I don't suspect many players will use this version. Adding a gameVersion would complicate this code and cause an public api break
