### PR TITLE
Add version id for 2022.10.18

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <VersionPrefix>1.7.2</VersionPrefix>
+    <VersionPrefix>1.7.3</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
     <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -28,6 +28,7 @@ namespace Impostor.Server.Net.Manager
             GameVersion.GetVersion(2022, 2, 2), // 2022.3.29 and 2022.4.19
             GameVersion.GetVersion(2022, 4, 20), // 2022.6.21 and 2022.7.12
             GameVersion.GetVersion(2022, 5, 12), // 2022.8.23
+            GameVersion.GetVersion(2022, 7, 25), // 2022.10.18
         };
 
         private readonly ILogger<ClientManager> _logger;

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -29,6 +29,7 @@ namespace Impostor.Server.Net.Manager
             GameVersion.GetVersion(2022, 4, 20), // 2022.6.21 and 2022.7.12
             GameVersion.GetVersion(2022, 5, 12), // 2022.8.23
             GameVersion.GetVersion(2022, 7, 25), // 2022.10.18
+            GameVersion.GetVersion(2022, 9, 2), // 2022.10.25
         };
 
         private readonly ILogger<ClientManager> _logger;


### PR DESCRIPTION
### Description

Among Us released a new update, 2022.10.18. It looks like no changes are necessary to get the game playable
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->
