### PR TITLE
Remove anticheat log when anticheat is disabled

### DIFF
--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -37,12 +37,12 @@ namespace Impostor.Server.Net
 
         public override async ValueTask<bool> ReportCheatAsync(CheatContext context, string message)
         {
-            _logger.LogWarning("Client {Name} ({Id}) was caught cheating: [{Context}] {Message}", Name, Id, context.Name, message);
-
             if (!_antiCheatConfig.Enabled)
             {
                 return false;
             }
+
+            _logger.LogWarning("Client {Name} ({Id}) was caught cheating: [{Context}] {Message}", Name, Id, context.Name, message);
 
             if (_antiCheatConfig.BanIpFromGame)
             {


### PR DESCRIPTION
### Description

Merges #456 (which I couldn't reopen anymore)

Currently my server log is getting spammed full more than before with anticheat warnings. Disable them so I still have useful logs remaining
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->