### PR TITLE
Allow sabotages by dead impostors

### DIFF
--- a/src/Impostor.Api/Innersloth/RoleTypes.cs
+++ b/src/Impostor.Api/Innersloth/RoleTypes.cs
@@ -8,5 +8,7 @@ namespace Impostor.Api.Innersloth
         Engineer,
         GuardianAngel,
         Shapeshifter,
+        CrewmateGhost,
+        ImpostorGhost,
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -34,7 +34,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public bool Disconnected { get; internal set; }
 
-        public bool IsImpostor => RoleType is RoleTypes.Impostor or RoleTypes.Shapeshifter;
+        public bool IsImpostor => RoleType is RoleTypes.Impostor or RoleTypes.Shapeshifter or RoleTypes.ImpostorGhost;
 
         public bool CanVent => RoleType is RoleTypes.Impostor or RoleTypes.Shapeshifter or RoleTypes.Engineer;
 


### PR DESCRIPTION
### Description

2021.12.8+ sets the role of dead players to {Crewmate,Impostor}Ghost, so relax the anticheat to allow sabotages by ImpostorGhosts

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->
