### PR TITLE
Automatically add ASP.Net Core to the library path

### DIFF
--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -27,7 +27,7 @@ namespace Impostor.Server.Plugins
             CheckPaths(pluginPaths);
             CheckPaths(libraryPaths);
 
-            // Add library path for ASP.Net Core. This is useful for plugins that depend on ASP.Net Core,
+            // Add library path for ASP.NET Core. This is useful for plugins that depend on ASP.NET Core,
             // like Impostor.Http. The path contains the .NET version number, so it changes regularly.
             var aspNetPath = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
                 .Replace("Microsoft.NETCore.App", "Microsoft.AspNetCore.App");
@@ -37,7 +37,7 @@ namespace Impostor.Server.Plugins
             }
             else
             {
-                Logger.Information("ASP.Net Core not installed, this may cause issues if you have plugins that depend on it");
+                Logger.Information("ASP.NET Core not installed, this may cause issues if you have plugins that depend on it");
             }
 
             var rootFolder = Directory.GetCurrentDirectory();

--- a/src/Impostor.Server/Plugins/PluginLoader.cs
+++ b/src/Impostor.Server/Plugins/PluginLoader.cs
@@ -27,6 +27,19 @@ namespace Impostor.Server.Plugins
             CheckPaths(pluginPaths);
             CheckPaths(libraryPaths);
 
+            // Add library path for ASP.Net Core. This is useful for plugins that depend on ASP.Net Core,
+            // like Impostor.Http. The path contains the .NET version number, so it changes regularly.
+            var aspNetPath = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory()
+                .Replace("Microsoft.NETCore.App", "Microsoft.AspNetCore.App");
+            if (Directory.Exists(aspNetPath))
+            {
+                libraryPaths.Add(aspNetPath);
+            }
+            else
+            {
+                Logger.Information("ASP.Net Core not installed, this may cause issues if you have plugins that depend on it");
+            }
+
             var rootFolder = Directory.GetCurrentDirectory();
 
             pluginPaths.Add(Path.Combine(rootFolder, "plugins"));


### PR DESCRIPTION
### Description

Currently Impostor.Http is becoming an almost mandatory plugin. Because it depends on ASP.Net, many people who fail to add the required path to their config will run into an error. Help them by automatically adding ASP.Net Core.

Also .NET updates every now and then and updating the version number in the config.json is annoying me.

This commit uses the fact that AspNetCore DLL's are in a sibling folder to the .NET runtime and should therefore work on most setups unless they've installed ASP.Net in a very weird way.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #
