### PR TITLE
Add missing game keywords

### DIFF
--- a/src/Impostor.Api/Innersloth/GameKeywords.cs
+++ b/src/Impostor.Api/Innersloth/GameKeywords.cs
@@ -21,6 +21,9 @@ namespace Impostor.Api.Innersloth
         SpanishEU = 1024,
         Arabic = 32,
         Polish = 128,
+        SChinese = 65536,
+        TChinese = 131072,
+        Irish = 262144,
         Other = 1,
     }
 }


### PR DESCRIPTION

### Description

These have been added in 2021.6.30, but this has only now been problematic because Impostor.Http requires this array to be accurate

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- Fix getting a 400 in Impostor.Http if you search for a game in Traditional/Simplified Chinese or Irish
