### PR TITLE
Reorder GameFull and GameStarted join errors

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Incoming.cs
+++ b/src/Impostor.Server/Net/State/Game.Incoming.cs
@@ -166,14 +166,6 @@ namespace Impostor.Server.Net.State
                 }
             }
 
-            // Check if;
-            // - The player is already in this game.
-            // - The game is full.
-            if (player?.Game != this && _players.Count >= Options.MaxPlayers)
-            {
-                return GameJoinResult.FromError(GameJoinError.GameFull);
-            }
-
             if (GameState == GameStates.Starting || GameState == GameStates.Started)
             {
                 return GameJoinResult.FromError(GameJoinError.GameStarted);
@@ -182,6 +174,14 @@ namespace Impostor.Server.Net.State
             if (GameState == GameStates.Destroyed)
             {
                 return GameJoinResult.FromError(GameJoinError.GameDestroyed);
+            }
+
+            // Check if;
+            // - The player is already in this game.
+            // - The game is full.
+            if (player?.Game != this && _players.Count >= Options.MaxPlayers)
+            {
+                return GameJoinResult.FromError(GameJoinError.GameFull);
             }
 
             var isNew = false;


### PR DESCRIPTION
### Description

If a game is in progress, a player can't join it anyway and spam-joining to see if a spot becomes available is useless. So the GameFull error is more important than the GameStarted error, therefore reorder them.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #518
