### PR TITLE
feat:Timeout Time configuable

### DIFF
--- a/src/Impostor.Api/Config/TimeoutConfig.cs
+++ b/src/Impostor.Api/Config/TimeoutConfig.cs
@@ -1,0 +1,10 @@
+namespace Impostor.Api.Config
+{
+    public class TimeoutConfig
+    {
+        public const string Section = "Timeout";
+
+        public int SpawnTimeout { get; set; } = 2500;
+        public int ConnectionTimeout { get; set; } = 2500;
+    }
+}

--- a/src/Impostor.Server/Constants.cs
+++ b/src/Impostor.Server/Constants.cs
@@ -1,7 +1,0 @@
-﻿namespace Impostor.Server
-{
-    internal static class Constants
-    {
-        public const int ConnectionTimeout = 2500;
-    }
-}

--- a/src/Impostor.Server/Constants.cs
+++ b/src/Impostor.Server/Constants.cs
@@ -2,7 +2,6 @@
 {
     internal static class Constants
     {
-        public const int SpawnTimeout = 2500;
         public const int ConnectionTimeout = 2500;
     }
 }

--- a/src/Impostor.Server/Net/State/ClientPlayer.cs
+++ b/src/Impostor.Server/Net/State/ClientPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Impostor.Api.Net;
@@ -13,11 +13,13 @@ namespace Impostor.Server.Net.State
     {
         private readonly ILogger<ClientPlayer> _logger;
         private readonly Timer _spawnTimeout;
+        private readonly int _spawnTimeoutTime;
 
-        public ClientPlayer(ILogger<ClientPlayer> logger, ClientBase client, Game game)
+        public ClientPlayer(ILogger<ClientPlayer> logger, ClientBase client, Game game, int timeOutTime)
         {
             _logger = logger;
             _spawnTimeout = new Timer(RunSpawnTimeout!, null, -1, -1);
+            _spawnTimeoutTime = timeOutTime;
 
             Game = game;
             Client = client;
@@ -41,7 +43,7 @@ namespace Impostor.Server.Net.State
 
         public void InitializeSpawnTimeout()
         {
-            _spawnTimeout.Change(Constants.SpawnTimeout, -1);
+            _spawnTimeout.Change(_spawnTimeoutTime, -1);
         }
 
         public void DisableSpawnTimeout()

--- a/src/Impostor.Server/Net/State/Game.Incoming.cs
+++ b/src/Impostor.Server/Net/State/Game.Incoming.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Impostor.Api.Games;
@@ -188,7 +188,7 @@ namespace Impostor.Server.Net.State
 
             if (player == null || player.Game != this)
             {
-                var clientPlayer = new ClientPlayer(_serviceProvider.GetRequiredService<ILogger<ClientPlayer>>(), client, this);
+                var clientPlayer = new ClientPlayer(_serviceProvider.GetRequiredService<ILogger<ClientPlayer>>(), client, this, _timeoutConfig.SpawnTimeout);
 
                 if (!_clientManager.Validate(client))
                 {

--- a/src/Impostor.Server/Net/State/Game.State.cs
+++ b/src/Impostor.Server/Net/State/Game.State.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using Impostor.Api;
 using Impostor.Api.Innersloth;
@@ -76,7 +76,7 @@ namespace Impostor.Server.Net.State
             // Player can refuse to be kicked and keep the connection open, check for this.
             _ = Task.Run(async () =>
             {
-                await Task.Delay(Constants.ConnectionTimeout);
+                await Task.Delay(_timeoutConfig.ConnectionTimeout);
 
                 if (player.Client.Connection.IsConnected && player.Client.Connection is HazelConnection hazel)
                 {

--- a/src/Impostor.Server/Net/State/Game.cs
+++ b/src/Impostor.Server/Net/State/Game.cs
@@ -30,6 +30,7 @@ namespace Impostor.Server.Net.State
         private readonly HashSet<IPAddress> _bannedIps;
         private readonly IEventManager _eventManager;
         private readonly CompatibilityConfig _compatibilityConfig;
+        private readonly TimeoutConfig _timeoutConfig;
 
         public Game(
             ILogger<Game> logger,
@@ -41,7 +42,8 @@ namespace Impostor.Server.Net.State
             GameFilterOptions filterOptions,
             ClientManager clientManager,
             IEventManager eventManager,
-            IOptions<CompatibilityConfig> compatibilityConfig)
+            IOptions<CompatibilityConfig> compatibilityConfig,
+            IOptions<TimeoutConfig> timeoutConfig)
         {
             _logger = logger;
             _serviceProvider = serviceProvider;
@@ -59,6 +61,7 @@ namespace Impostor.Server.Net.State
             _clientManager = clientManager;
             _eventManager = eventManager;
             _compatibilityConfig = compatibilityConfig.Value;
+            _timeoutConfig = timeoutConfig.Value;
             Items = new ConcurrentDictionary<object, object>();
         }
 

--- a/src/Impostor.Server/Program.cs
+++ b/src/Impostor.Server/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -99,6 +99,7 @@ namespace Impostor.Server
                     services.Configure<AntiCheatConfig>(host.Configuration.GetSection(AntiCheatConfig.Section));
                     services.Configure<CompatibilityConfig>(host.Configuration.GetSection(CompatibilityConfig.Section));
                     services.Configure<ServerConfig>(host.Configuration.GetSection(ServerConfig.Section));
+                    services.Configure<TimeoutConfig>(host.Configuration.GetSection(TimeoutConfig.Section));
 
                     services.AddSingleton<ClientManager>();
                     services.AddSingleton<IClientManager>(p => p.GetRequiredService<ClientManager>());

--- a/src/Impostor.Server/config-full.json
+++ b/src/Impostor.Server/config-full.json
@@ -9,6 +9,10 @@
     "Enabled": true,
     "BanIpFromGame": true
   },
+  "Timeout": {
+    "SpawnTimeout": 2500,
+    "ConnectionTimeout": 2500
+  },
   "Compatibility": {
     "AllowFutureGameVersions": false,
     "AllowVersionMixing": false


### PR DESCRIPTION
### Description
Since the timeout time varies depending on server specs, connection speed, and mods installed by the player, I have made it configuable in `config.json` in this PR.

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes # None
