### PR TITLE
Improve cross-compatibility

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <LangVersion>11</LangVersion>
-    <VersionPrefix>1.8.4</VersionPrefix>
+    <VersionPrefix>1.9.0</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
     <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Impostor.Api/Innersloth/GameVersion.cs
+++ b/src/Impostor.Api/Innersloth/GameVersion.cs
@@ -5,6 +5,10 @@ namespace Impostor.Api.Innersloth
 {
     public readonly struct GameVersion : IEquatable<GameVersion>, IComparable<GameVersion>, IComparisonOperators<GameVersion, GameVersion, bool>
     {
+        private const int YearMask = 25000;
+        private const int MonthMask = 1800;
+        private const int DayMask = 50;
+
         public GameVersion(int value)
         {
             Value = value;
@@ -12,10 +16,18 @@ namespace Impostor.Api.Innersloth
 
         public GameVersion(int year, int month, int day, int revision = 0)
         {
-            Value = (year * 25000) + (month * 1800) + (day * 50) + revision;
+            Value = (year * YearMask) + (month * MonthMask) + (day * DayMask) + revision;
         }
 
         public int Value { get; }
+
+        public int Year => Value / YearMask;
+
+        public int Month => (Value % YearMask) / MonthMask;
+
+        public int Day => ((Value % YearMask) % MonthMask) / DayMask;
+
+        public int Revision => Value % DayMask;
 
         public static bool operator ==(GameVersion left, GameVersion right) => left.Value == right.Value;
 
@@ -32,19 +44,19 @@ namespace Impostor.Api.Innersloth
         public void GetComponents(out int year, out int month, out int day, out int revision)
         {
             var value = Value;
-            year = value / 25000;
-            value %= 25000;
-            month = value / 1800;
-            value %= 1800;
-            day = value / 50;
-            revision = value % 50;
+            year = value / YearMask;
+            value %= YearMask;
+            month = value / MonthMask;
+            value %= MonthMask;
+            day = value / DayMask;
+            revision = value % DayMask;
         }
 
         public GameVersion ExtractDisableServerAuthority(out bool disableServerAuthority)
         {
             const int DisableServerAuthorityFlag = 25;
 
-            var revision = Value % 50;
+            var revision = Value % DayMask;
             if (revision >= DisableServerAuthorityFlag)
             {
                 disableServerAuthority = true;

--- a/src/Impostor.Api/Innersloth/GameVersion.cs
+++ b/src/Impostor.Api/Innersloth/GameVersion.cs
@@ -1,20 +1,84 @@
+using System;
+using System.Numerics;
+
 namespace Impostor.Api.Innersloth
 {
-    public static class GameVersion
+    public readonly struct GameVersion : IEquatable<GameVersion>, IComparable<GameVersion>, IComparisonOperators<GameVersion, GameVersion, bool>
     {
-        public static int GetVersion(int year, int month, int day, int revision = 0)
+        public GameVersion(int value)
         {
-            return (year * 25000) + (month * 1800) + (day * 50) + revision;
+            Value = value;
         }
 
-        public static void ParseVersion(int version, out int year, out int month, out int day, out int revision)
+        public GameVersion(int year, int month, int day, int revision = 0)
         {
-            year = version / 25000;
-            version %= 25000;
-            month = version / 1800;
-            version %= 1800;
-            day = version / 50;
-            revision = version % 50;
+            Value = (year * 25000) + (month * 1800) + (day * 50) + revision;
+        }
+
+        public int Value { get; }
+
+        public static bool operator ==(GameVersion left, GameVersion right) => left.Value == right.Value;
+
+        public static bool operator !=(GameVersion left, GameVersion right) => left.Value != right.Value;
+
+        public static bool operator >(GameVersion left, GameVersion right) => left.Value > right.Value;
+
+        public static bool operator >=(GameVersion left, GameVersion right) => left.Value >= right.Value;
+
+        public static bool operator <(GameVersion left, GameVersion right) => left.Value < right.Value;
+
+        public static bool operator <=(GameVersion left, GameVersion right) => left.Value <= right.Value;
+
+        public void GetComponents(out int year, out int month, out int day, out int revision)
+        {
+            var value = Value;
+            year = value / 25000;
+            value %= 25000;
+            month = value / 1800;
+            value %= 1800;
+            day = value / 50;
+            revision = value % 50;
+        }
+
+        public GameVersion ExtractDisableServerAuthority(out bool disableServerAuthority)
+        {
+            const int DisableServerAuthorityFlag = 25;
+
+            var revision = Value % 50;
+            if (revision >= DisableServerAuthorityFlag)
+            {
+                disableServerAuthority = true;
+                return new GameVersion(Value - DisableServerAuthorityFlag);
+            }
+
+            disableServerAuthority = false;
+            return this;
+        }
+
+        public override string ToString()
+        {
+            GetComponents(out var year, out var month, out var day, out var revision);
+            return $"{year}.{month}.{day}{(revision == 0 ? string.Empty : "." + revision)}";
+        }
+
+        public int CompareTo(GameVersion other)
+        {
+            return Value.CompareTo(other.Value);
+        }
+
+        public bool Equals(GameVersion other)
+        {
+            return Value == other.Value;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is GameVersion other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return Value;
         }
     }
 }

--- a/src/Impostor.Api/Innersloth/GameVersion.cs
+++ b/src/Impostor.Api/Innersloth/GameVersion.cs
@@ -9,6 +9,8 @@ namespace Impostor.Api.Innersloth
         private const int MonthMask = 1800;
         private const int DayMask = 50;
 
+        private const int DisableServerAuthorityFlag = 25;
+
         public GameVersion(int value)
         {
             Value = value;
@@ -28,6 +30,17 @@ namespace Impostor.Api.Innersloth
         public int Day => ((Value % YearMask) % MonthMask) / DayMask;
 
         public int Revision => Value % DayMask;
+
+        /// <summary>
+        /// Gets a value indicating whether the DisableServerAuthority flag is present.
+        /// </summary>
+        public bool HasDisableServerAuthorityFlag
+        {
+            get
+            {
+                return Revision >= DisableServerAuthorityFlag;
+            }
+        }
 
         public static bool operator ==(GameVersion left, GameVersion right) => left.Value == right.Value;
 
@@ -52,19 +65,13 @@ namespace Impostor.Api.Innersloth
             revision = value % DayMask;
         }
 
-        public GameVersion ExtractDisableServerAuthority(out bool disableServerAuthority)
+        /// <summary>
+        /// Normalizes this game version by removing all the special flags.
+        /// </summary>
+        /// <returns>This GameVersion but stripped of special flags.</returns>
+        public GameVersion Normalize()
         {
-            const int DisableServerAuthorityFlag = 25;
-
-            var revision = Value % DayMask;
-            if (revision >= DisableServerAuthorityFlag)
-            {
-                disableServerAuthority = true;
-                return new GameVersion(Value - DisableServerAuthorityFlag);
-            }
-
-            disableServerAuthority = false;
-            return this;
+            return HasDisableServerAuthorityFlag ? new GameVersion(Value - DisableServerAuthorityFlag) : this;
         }
 
         public override string ToString()

--- a/src/Impostor.Api/Net/IClient.cs
+++ b/src/Impostor.Api/Net/IClient.cs
@@ -67,7 +67,7 @@ namespace Impostor.Api.Net
         /// <summary>
         /// Gets the version of the game the client is using.
         /// </summary>
-        int GameVersion { get; }
+        GameVersion GameVersion { get; }
 
         /// <summary>
         /// Gets platform specific data of the <see cref="IClient" />.

--- a/src/Impostor.Api/Net/Manager/ICompatibilityManager.cs
+++ b/src/Impostor.Api/Net/Manager/ICompatibilityManager.cs
@@ -37,9 +37,11 @@ namespace Impostor.Api.Net.Manager
         /// <param name="hostVersion">The client version of the host.</param>
         /// <param name="clientVersion">The client version of the player that is joining.</param>
         /// <returns>
-        /// - GameJoinError.None if everything is OK
-        /// - GameJoinError.ClientOutdated if the player runs a too old game version
-        /// - GameJoinError.ClientTooNew if the player runs a too new game version.
+        /// <list type="bullet">
+        ///   <item><see cref="GameJoinError.None"/> if everything is OK.</item>
+        ///   <item><see cref="GameJoinError.ClientOutdated"/> if the player runs a too old game version.</item>
+        ///   <item><see cref="GameJoinError.ClientTooNew"/> if the player runs a too new game version.</item>
+        /// </list>
         /// </returns>
         public GameJoinError CanJoinGame(GameVersion hostVersion, GameVersion clientVersion);
 

--- a/src/Impostor.Api/Net/Manager/ICompatibilityManager.cs
+++ b/src/Impostor.Api/Net/Manager/ICompatibilityManager.cs
@@ -1,0 +1,61 @@
+namespace Impostor.Api.Net.Manager
+{
+    /**
+     * <summary>
+     * Maintain an internal compatibility list of versions that are allowed to connect to the server, and which game
+     * versions they are allowed to play with.
+     * </summary>
+     */
+    public interface ICompatibilityManager
+    {
+        public enum VersionCompareResult
+        {
+            Compatible,
+            ClientTooOld,
+            ServerTooOld,
+            Unknown,
+        }
+
+        /**
+         * <summary>
+         * Get the compatibility group of a certain client version. If two versions are in the same compatibility group,
+         * they can play a game together without issues.
+         * </summary>
+         * <param name="clientVersion">The client version to check for.</param>
+         * <param name="compatGroup">If the result is Compatible, the compat group.</param>
+         * <returns>
+         * Whether this version is supported by the server at the moment and if not, whether it is too old or too new.
+         * </returns>
+         */
+        public VersionCompareResult TryGetCompatibilityGroup(int clientVersion, out int? compatGroup);
+
+        /**
+         * <summary>
+         * Add a supported game version to the internal version compatibility list. If this version is already on the
+         * compatibility list, modify its configuration.
+         *
+         * WARNING: this method does not magically make changes to Impostor to properly support these versions. If
+         * Impostor cannot support the game versions you're trying to add or that the game versions you're making
+         * compatible do not crossplay correctly, weird behaviour may occur. Here be dragons.
+         * </summary>
+         * <param name="gameVersion">The game version to add details to.</param>
+         * <param name="compatGroup">The compatibility group to add this version to. Customary is to use the broadcast
+         * version of the lowest game version it is compatible with.</param>
+         * <param name="includeInSupportRange">
+         * Whether to add this version to the list of minimum/maximum game versions supported.
+         * </param>
+         */
+        public void AddSupportedVersion(int gameVersion, int compatGroup, bool includeInSupportRange = true);
+
+        /**
+         * <summary>
+         * Remove a version from the internal version compatibility list.
+         * </summary>
+         * Note that this will not stop players currently connected to the server from playing, it will only stop new
+         * connections.
+         * <param name="removedVersion">The version to remove from the list.</param>
+         * <returns>True iff this version was on the current compatibility list.</returns>
+         */
+        public bool RemoveSupportedVersion(int removedVersion);
+    }
+}

--- a/src/Impostor.Api/Net/Manager/ICompatibilityManager.cs
+++ b/src/Impostor.Api/Net/Manager/ICompatibilityManager.cs
@@ -1,3 +1,5 @@
+using Impostor.Api.Games;
+
 namespace Impostor.Api.Net.Manager
 {
     /**
@@ -16,46 +18,45 @@ namespace Impostor.Api.Net.Manager
             Unknown,
         }
 
-        /**
-         * <summary>
-         * Get the compatibility group of a certain client version. If two versions are in the same compatibility group,
-         * they can play a game together without issues.
-         * </summary>
-         * <param name="clientVersion">The client version to check for.</param>
-         * <param name="compatGroup">If the result is Compatible, the compat group.</param>
-         * <returns>
-         * Whether this version is supported by the server at the moment and if not, whether it is too old or too new.
-         * </returns>
-         */
-        public VersionCompareResult TryGetCompatibilityGroup(int clientVersion, out int? compatGroup);
+        /// <summary>
+        /// Check if a client can join the server according to the currently accepted game versions.
+        /// </summary>
+        /// <param name="clientVersion">The client version to check for.</param>
+        /// <returns>
+        /// Whether this version is supported by the server at the moment and if not, whether it is too old or too new.
+        /// </returns>
+        public VersionCompareResult CanConnectToServer(int clientVersion);
 
-        /**
-         * <summary>
-         * Add a supported game version to the internal version compatibility list. If this version is already on the
-         * compatibility list, modify its configuration.
-         *
-         * WARNING: this method does not magically make changes to Impostor to properly support these versions. If
-         * Impostor cannot support the game versions you're trying to add or that the game versions you're making
-         * compatible do not crossplay correctly, weird behaviour may occur. Here be dragons.
-         * </summary>
-         * <param name="gameVersion">The game version to add details to.</param>
-         * <param name="compatGroup">The compatibility group to add this version to. Customary is to use the broadcast
-         * version of the lowest game version it is compatible with.</param>
-         * <param name="includeInSupportRange">
-         * Whether to add this version to the list of minimum/maximum game versions supported.
-         * </param>
-         */
-        public void AddSupportedVersion(int gameVersion, int compatGroup, bool includeInSupportRange = true);
+        /// <summary>Check if a player can join an existing game.</summary>
+        /// <param name="hostVersion">The client version of the host.</param>
+        /// <param name="playerVersion">The client version of the player that is joining.</param>
+        /// <returns>
+        /// - GameJoinError.None if everything is OK
+        /// - GameJoinError.ClientOutdated if the player runs a too old game version
+        /// - GameJoinError.ClientTooNew if the player runs a too new game version
+        /// </returns>
+        public GameJoinError CanJoinGame(int hostVersion, int playerVersion);
 
-        /**
-         * <summary>
-         * Remove a version from the internal version compatibility list.
-         * </summary>
-         * Note that this will not stop players currently connected to the server from playing, it will only stop new
-         * connections.
-         * <param name="removedVersion">The version to remove from the list.</param>
-         * <returns>True iff this version was on the current compatibility list.</returns>
-         */
+        /// <summary>
+        /// Add a supported game version to the internal version compatibility list. If this version is already on the
+        /// compatibility list, modify its configuration.
+        ///
+        /// WARNING: this method does not magically make changes to Impostor to properly support these versions. If
+        /// Impostor cannot support the game versions you're trying to add or that the game versions you're making
+        /// compatible do not crossplay correctly, weird behaviour may occur. Here be dragons.
+        /// </summary>
+        /// <param name="gameVersion">The game version to add details to.</param>
+        /// <param name="compatGroup">The compatibility group to add this version to. Customary is to use the broadcast
+        /// version of the lowest game version it is compatible with.</param>
+        public void AddSupportedVersion(int gameVersion, int compatGroup);
+
+        /// <summary>
+        /// Remove a version from the internal version compatibility list.
+        /// </summary>
+        /// Note that this will not stop players currently connected to the server from playing, it will only stop new
+        /// connections.
+        /// <param name="removedVersion">The version to remove from the list.</param>
+        /// <returns>True iff this version was on the current compatibility list.</returns>
         public bool RemoveSupportedVersion(int removedVersion);
     }
 }

--- a/src/Impostor.Api/Net/MessageReaderExtensions.cs
+++ b/src/Impostor.Api/Net/MessageReaderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Impostor.Api.Games;
+using Impostor.Api.Innersloth;
 using Impostor.Api.Net.Inner;
 using Impostor.Api.Unity;
 
@@ -7,6 +8,11 @@ namespace Impostor.Api.Net;
 
 public static class MessageReaderExtensions
 {
+    public static GameVersion ReadGameVersion(this IMessageReader reader)
+    {
+        return new GameVersion(reader.ReadInt32());
+    }
+
     public static T? ReadNetObject<T>(this IMessageReader reader, IGame game)
         where T : IInnerNetObject
     {

--- a/src/Impostor.Api/Net/MessageWriterExtensions.cs
+++ b/src/Impostor.Api/Net/MessageWriterExtensions.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Impostor.Api.Games;
+using Impostor.Api.Innersloth;
 using Impostor.Api.Net.Inner;
 using Impostor.Api.Unity;
 
@@ -7,6 +8,11 @@ namespace Impostor.Api.Net;
 
 public static class MessageWriterExtensions
 {
+    public static void Write(this IMessageWriter writer, GameVersion value)
+    {
+        writer.Write(value.Value);
+    }
+
     public static void Serialize(this GameCode gameCode, IMessageWriter writer)
     {
         writer.Write(gameCode.Value);

--- a/src/Impostor.Api/Net/Messages/C2S/HandshakeC2S.cs
+++ b/src/Impostor.Api/Net/Messages/C2S/HandshakeC2S.cs
@@ -4,9 +4,9 @@ namespace Impostor.Api.Net.Messages.C2S
 {
     public static class HandshakeC2S
     {
-        public static void Deserialize(IMessageReader reader, out int clientVersion, out string name, out Language language, out QuickChatModes chatMode, out PlatformSpecificData? platformSpecificData)
+        public static void Deserialize(IMessageReader reader, out GameVersion clientVersion, out string name, out Language language, out QuickChatModes chatMode, out PlatformSpecificData? platformSpecificData)
         {
-            clientVersion = reader.ReadInt32();
+            clientVersion = reader.ReadGameVersion();
             name = reader.ReadString();
 
             if (clientVersion >= Version.V1)
@@ -44,13 +44,13 @@ namespace Impostor.Api.Net.Messages.C2S
 
         private static class Version
         {
-            public static readonly int V1 = GameVersion.GetVersion(2021, 4, 25);
+            public static readonly GameVersion V1 = new(2021, 4, 25);
 
-            public static readonly int V2 = GameVersion.GetVersion(2021, 6, 30);
+            public static readonly GameVersion V2 = new(2021, 6, 30);
 
-            public static readonly int V3 = GameVersion.GetVersion(2021, 11, 9);
+            public static readonly GameVersion V3 = new(2021, 11, 9);
 
-            public static readonly int V4 = GameVersion.GetVersion(2021, 12, 14);
+            public static readonly GameVersion V4 = new(2021, 12, 14);
         }
     }
 }

--- a/src/Impostor.Api/Net/Messages/S2C/Message07JoinedGameS2C.cs
+++ b/src/Impostor.Api/Net/Messages/S2C/Message07JoinedGameS2C.cs
@@ -4,7 +4,7 @@ namespace Impostor.Api.Net.Messages.S2C
 {
     public static class Message07JoinedGameS2C
     {
-        public static void Serialize(IMessageWriter writer, bool clear, int gameCode, int playerId, int hostId, IClientPlayer[] otherPlayers, bool post20220202 = true)
+        public static void Serialize(IMessageWriter writer, bool clear, int gameCode, int playerId, int hostId, IClientPlayer[] otherPlayers)
         {
             if (clear)
             {
@@ -24,12 +24,9 @@ namespace Impostor.Api.Net.Messages.S2C
                 ply.Client.PlatformSpecificData.Serialize(writer);
                 writer.WritePacked(ply.Character?.PlayerInfo.PlayerLevel ?? 1);
 
-                if (post20220202)
-                {
-                    // ProductUserId and FriendCode are not yet known, so set them to an empty string
-                    writer.Write(string.Empty);
-                    writer.Write(string.Empty);
-                }
+                // ProductUserId and FriendCode are not yet known, so set them to an empty string
+                writer.Write(string.Empty);
+                writer.Write(string.Empty);
             }
 
             writer.EndMessage();

--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -26,7 +26,7 @@ namespace Impostor.Server.Net
         private readonly GameManager _gameManager;
         private readonly ICustomMessageManager<ICustomRootMessage> _customMessageManager;
 
-        public Client(ILogger<Client> logger, IOptions<AntiCheatConfig> antiCheatOptions, ClientManager clientManager, GameManager gameManager, ICustomMessageManager<ICustomRootMessage> customMessageManager, string name, int gameVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData, IHazelConnection connection)
+        public Client(ILogger<Client> logger, IOptions<AntiCheatConfig> antiCheatOptions, ClientManager clientManager, GameManager gameManager, ICustomMessageManager<ICustomRootMessage> customMessageManager, string name, GameVersion gameVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData, IHazelConnection connection)
             : base(name, gameVersion, language, chatMode, platformSpecificData, connection)
         {
             _logger = logger;

--- a/src/Impostor.Server/Net/ClientBase.cs
+++ b/src/Impostor.Server/Net/ClientBase.cs
@@ -10,7 +10,7 @@ namespace Impostor.Server.Net
 {
     internal abstract class ClientBase : IClient
     {
-        protected ClientBase(string name, int gameVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData, IHazelConnection connection)
+        protected ClientBase(string name, GameVersion gameVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData, IHazelConnection connection)
         {
             Name = name;
             GameVersion = gameVersion;
@@ -31,7 +31,7 @@ namespace Impostor.Server.Net
 
         public PlatformSpecificData PlatformSpecificData { get; }
 
-        public int GameVersion { get; }
+        public GameVersion GameVersion { get; }
 
         public IHazelConnection Connection { get; }
 

--- a/src/Impostor.Server/Net/Factories/ClientFactory.cs
+++ b/src/Impostor.Server/Net/Factories/ClientFactory.cs
@@ -15,7 +15,7 @@ namespace Impostor.Server.Net.Factories
             _serviceProvider = serviceProvider;
         }
 
-        public ClientBase Create(IHazelConnection connection, string name, int clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData)
+        public ClientBase Create(IHazelConnection connection, string name, GameVersion clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData)
         {
             var client = ActivatorUtilities.CreateInstance<TClient>(_serviceProvider, name, clientVersion, language, chatMode, platformSpecificData, connection);
             connection.Client = client;

--- a/src/Impostor.Server/Net/Factories/IClientFactory.cs
+++ b/src/Impostor.Server/Net/Factories/IClientFactory.cs
@@ -5,6 +5,6 @@ namespace Impostor.Server.Net.Factories
 {
     internal interface IClientFactory
     {
-        ClientBase Create(IHazelConnection connection, string name, int clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData);
+        ClientBase Create(IHazelConnection connection, string name, GameVersion clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData);
     }
 }

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -56,7 +56,7 @@ namespace Impostor.Server.Net.Manager
 
         public async ValueTask RegisterConnectionAsync(IHazelConnection connection, string name, int clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData? platformSpecificData)
         {
-            var versionCompare = _compatibilityManager.TryGetCompatibilityGroup(clientVersion, out _);
+            var versionCompare = _compatibilityManager.CanConnectToServer(clientVersion);
             if (versionCompare == ICompatibilityManager.VersionCompareResult.ServerTooOld && _compatibilityConfig.AllowFutureGameVersions && platformSpecificData != null)
             {
                 GameVersion.ParseVersion(clientVersion, out var year, out var month, out var day, out var revision);

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Impostor.Api.Config;
 using Impostor.Api.Events.Managers;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Net;
+using Impostor.Api.Net.Manager;
 using Impostor.Hazel;
 using Impostor.Server.Events.Client;
 using Impostor.Server.Net.Factories;
@@ -18,40 +18,22 @@ namespace Impostor.Server.Net.Manager
 {
     internal partial class ClientManager
     {
-        // NOTE: when updating this array, keep the versions ordered from old to new, otherwise the version compare logic doesn't work properly
-        private static readonly int[] SupportedVersions =
-        {
-            GameVersion.GetVersion(2022, 11, 1), // 2022.12.8
-            GameVersion.GetVersion(2022, 11, 9), // 2022.12.14
-            GameVersion.GetVersion(2022, 12, 2), // 2023.2.28
-            GameVersion.GetVersion(2023, 1, 11), // 2023.3.28s
-            GameVersion.GetVersion(2023, 3, 13), // 2023.3.28a
-            GameVersion.GetVersion(2023, 4, 21), // 2023.6.13
-            GameVersion.GetVersion(2023, 5, 20), // 2023.7.11
-        };
-
         private readonly ILogger<ClientManager> _logger;
         private readonly IEventManager _eventManager;
         private readonly ConcurrentDictionary<int, ClientBase> _clients;
+        private readonly ICompatibilityManager _compatibilityManager;
         private readonly CompatibilityConfig _compatibilityConfig;
         private readonly IClientFactory _clientFactory;
         private int _idLast;
 
-        public ClientManager(ILogger<ClientManager> logger, IEventManager eventManager, IClientFactory clientFactory, IOptions<CompatibilityConfig> compatibilityConfig)
+        public ClientManager(ILogger<ClientManager> logger, IEventManager eventManager, IClientFactory clientFactory, ICompatibilityManager compatibilityManager, IOptions<CompatibilityConfig> compatibilityConfig)
         {
             _logger = logger;
             _eventManager = eventManager;
             _clientFactory = clientFactory;
             _clients = new ConcurrentDictionary<int, ClientBase>();
+            _compatibilityManager = compatibilityManager;
             _compatibilityConfig = compatibilityConfig.Value;
-        }
-
-        private enum VersionCompareResult
-        {
-            Compatible,
-            ClientTooOld,
-            ServerTooOld,
-            Unknown,
         }
 
         public IEnumerable<ClientBase> Clients => _clients.Values;
@@ -74,13 +56,13 @@ namespace Impostor.Server.Net.Manager
 
         public async ValueTask RegisterConnectionAsync(IHazelConnection connection, string name, int clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData? platformSpecificData)
         {
-            var versionCompare = CompareVersion(clientVersion);
-            if (versionCompare == VersionCompareResult.ServerTooOld && _compatibilityConfig.AllowFutureGameVersions && platformSpecificData != null)
+            var versionCompare = _compatibilityManager.TryGetCompatibilityGroup(clientVersion, out _);
+            if (versionCompare == ICompatibilityManager.VersionCompareResult.ServerTooOld && _compatibilityConfig.AllowFutureGameVersions && platformSpecificData != null)
             {
                 GameVersion.ParseVersion(clientVersion, out var year, out var month, out var day, out var revision);
                 _logger.LogWarning("Client connected using future version: {clientVersion} ({version}). Unsupported, continue at your own risk.", clientVersion, $"{year}.{month}.{day}{(revision == 0 ? string.Empty : "." + revision)}");
             }
-            else if (versionCompare != VersionCompareResult.Compatible || platformSpecificData == null)
+            else if (versionCompare != ICompatibilityManager.VersionCompareResult.Compatible || platformSpecificData == null)
             {
                 GameVersion.ParseVersion(clientVersion, out var year, out var month, out var day, out var revision);
                 _logger.LogTrace("Client connected using unsupported version: {clientVersion} ({version})", clientVersion, $"{year}.{month}.{day}{(revision == 0 ? string.Empty : "." + revision)}");
@@ -89,9 +71,9 @@ namespace Impostor.Server.Net.Manager
 
                 var message = versionCompare switch
                 {
-                    VersionCompareResult.ClientTooOld => DisconnectMessages.VersionClientTooOld,
-                    VersionCompareResult.ServerTooOld => DisconnectMessages.VersionServerTooOld,
-                    VersionCompareResult.Unknown => DisconnectMessages.VersionUnsupported,
+                    ICompatibilityManager.VersionCompareResult.ClientTooOld => DisconnectMessages.VersionClientTooOld,
+                    ICompatibilityManager.VersionCompareResult.ServerTooOld => DisconnectMessages.VersionServerTooOld,
+                    ICompatibilityManager.VersionCompareResult.Unknown => DisconnectMessages.VersionUnsupported,
                     _ => throw new ArgumentOutOfRangeException(),
                 };
 
@@ -132,30 +114,6 @@ namespace Impostor.Server.Net.Manager
             return client.Id != 0
                    && _clients.TryGetValue(client.Id, out var registeredClient)
                    && ReferenceEquals(client, registeredClient);
-        }
-
-        private VersionCompareResult CompareVersion(int clientVersion)
-        {
-            foreach (var serverVersion in SupportedVersions)
-            {
-                if (clientVersion == serverVersion)
-                {
-                    return VersionCompareResult.Compatible;
-                }
-            }
-
-            if (clientVersion < SupportedVersions[0])
-            {
-                return VersionCompareResult.ClientTooOld;
-            }
-
-            if (clientVersion > SupportedVersions.Last())
-            {
-                return VersionCompareResult.ServerTooOld;
-            }
-
-            // This may happen in the very rare case that version X is supported, X+2 is as well, but X+1 is not.
-            return VersionCompareResult.Unknown;
         }
     }
 }

--- a/src/Impostor.Server/Net/Manager/ClientManager.cs
+++ b/src/Impostor.Server/Net/Manager/ClientManager.cs
@@ -54,18 +54,16 @@ namespace Impostor.Server.Net.Manager
             return clientId;
         }
 
-        public async ValueTask RegisterConnectionAsync(IHazelConnection connection, string name, int clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData? platformSpecificData)
+        public async ValueTask RegisterConnectionAsync(IHazelConnection connection, string name, GameVersion clientVersion, Language language, QuickChatModes chatMode, PlatformSpecificData? platformSpecificData)
         {
             var versionCompare = _compatibilityManager.CanConnectToServer(clientVersion);
             if (versionCompare == ICompatibilityManager.VersionCompareResult.ServerTooOld && _compatibilityConfig.AllowFutureGameVersions && platformSpecificData != null)
             {
-                GameVersion.ParseVersion(clientVersion, out var year, out var month, out var day, out var revision);
-                _logger.LogWarning("Client connected using future version: {clientVersion} ({version}). Unsupported, continue at your own risk.", clientVersion, $"{year}.{month}.{day}{(revision == 0 ? string.Empty : "." + revision)}");
+                _logger.LogWarning("Client connected using future version: {clientVersion} ({version}). Unsupported, continue at your own risk.", clientVersion.Value, clientVersion.ToString());
             }
             else if (versionCompare != ICompatibilityManager.VersionCompareResult.Compatible || platformSpecificData == null)
             {
-                GameVersion.ParseVersion(clientVersion, out var year, out var month, out var day, out var revision);
-                _logger.LogTrace("Client connected using unsupported version: {clientVersion} ({version})", clientVersion, $"{year}.{month}.{day}{(revision == 0 ? string.Empty : "." + revision)}");
+                _logger.LogTrace("Client connected using unsupported version: {clientVersion} ({version})", clientVersion.Value, clientVersion.ToString());
 
                 using var packet = MessageWriter.Get(MessageType.Reliable);
 

--- a/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
+++ b/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using Impostor.Api.Innersloth;
+using Impostor.Api.Net.Manager;
+using Microsoft.Extensions.Logging;
+
+namespace Impostor.Server.Net.Manager
+{
+    internal class CompatibilityManager : ICompatibilityManager
+    {
+        private static readonly CompatData[] DefaultSupportedVersions =
+        {
+            new(GameVersion.GetVersion(2022, 11, 1), GameVersion.GetVersion(2022, 11, 1), true), // 2022.12.8
+
+            new(GameVersion.GetVersion(2022, 11, 9), GameVersion.GetVersion(2022, 11, 9), true), // 2022.12.14
+
+            new(GameVersion.GetVersion(2022, 12, 2), GameVersion.GetVersion(2022, 12, 2), true), // 2023.2.28
+
+            new(GameVersion.GetVersion(2023, 1, 11), GameVersion.GetVersion(2023, 1, 11), true), // 2023.3.28s
+            new(GameVersion.GetVersion(2023, 3, 13), GameVersion.GetVersion(2023, 1, 11), true), // 2023.3.28a
+            new(GameVersion.GetVersion(2023, 4, 21), GameVersion.GetVersion(2023, 1, 11), true), // 2023.6.13
+
+            new(GameVersion.GetVersion(2023, 5, 20), GameVersion.GetVersion(2023, 5, 20), true), // 2023.7.11
+            new(GameVersion.GetVersion(2222, 0, 0), GameVersion.GetVersion(2023, 5, 20), false), // 2023.7.11 for host-only mods
+        };
+
+        // Map from client version to compatibility group
+        private readonly Dictionary<int, int> _supportMap = new Dictionary<int, int>();
+        private readonly ILogger<CompatibilityManager> _logger;
+        private readonly bool initializationFinished;
+        private int _lowestVersionSupported = int.MaxValue;
+        private int _highestVersionSupported = 0;
+
+        public CompatibilityManager(ILogger<CompatibilityManager> logger)
+        {
+            _logger = logger;
+            initializationFinished = false;
+            foreach (var compatData in DefaultSupportedVersions)
+            {
+                AddSupportedVersion(compatData.GameVersion, compatData.CompatGroup, compatData.IncludeInSupportRange);
+            }
+
+            ModifiedByUser = false;
+            initializationFinished = true;
+        }
+
+        internal bool ModifiedByUser { get; private set; }
+
+        public ICompatibilityManager.VersionCompareResult TryGetCompatibilityGroup(int clientVersion, out int? compatGroup)
+        {
+            compatGroup = null;
+            if (_supportMap.TryGetValue(clientVersion, out var compat))
+            {
+                compatGroup = compat;
+                return ICompatibilityManager.VersionCompareResult.Compatible;
+            }
+            else if (clientVersion < _lowestVersionSupported)
+            {
+                return ICompatibilityManager.VersionCompareResult.ClientTooOld;
+            }
+            else if (clientVersion > _highestVersionSupported)
+            {
+                return ICompatibilityManager.VersionCompareResult.ServerTooOld;
+            }
+            else
+            {
+                return ICompatibilityManager.VersionCompareResult.Unknown;
+            }
+        }
+
+        public void AddSupportedVersion(int gameVersion, int compatGroup, bool includeInSupportRange)
+        {
+            if (initializationFinished)
+            {
+                ModifiedByUser = true;
+                _logger.LogWarning("AddSupportedVersion was called by a plugin, this can create unexpected issues. Please proceed carefully");
+            }
+
+            _supportMap[gameVersion] = compatGroup;
+            if (includeInSupportRange)
+            {
+                if (gameVersion < _lowestVersionSupported)
+                {
+                    _lowestVersionSupported = gameVersion;
+                }
+
+                if (gameVersion > _highestVersionSupported)
+                {
+                    _highestVersionSupported = gameVersion;
+                }
+            }
+        }
+
+        public bool RemoveSupportedVersion(int removedVersion)
+        {
+            return _supportMap.Remove(removedVersion);
+        }
+
+        internal record CompatData(int GameVersion, int CompatGroup, bool IncludeInSupportRange);
+    }
+}

--- a/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
+++ b/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
@@ -70,7 +70,7 @@ internal class CompatibilityManager : ICompatibilityManager
     {
         // Innersloth servers allow disabling server authority by incrementing the version revision by 25.
         // We should allow crossplay between client versions with this flag set and those without.
-        clientVersion = clientVersion.ExtractDisableServerAuthority(out _);
+        clientVersion = clientVersion.Normalize();
 
         if (_supportMap.TryGetValue(clientVersion, out var compatibilityGroup))
         {

--- a/src/Impostor.Server/Net/Manager/GameManager.cs
+++ b/src/Impostor.Server/Net/Manager/GameManager.cs
@@ -65,7 +65,7 @@ namespace Impostor.Server.Net.Manager
             MapFlags map,
             int impostorCount,
             GameKeywords language,
-            int gameVersion,
+            GameVersion gameVersion,
             HashSet<string> filterTags,
             int count = 10)
         {

--- a/src/Impostor.Server/Net/State/Game.Incoming.cs
+++ b/src/Impostor.Server/Net/State/Game.Incoming.cs
@@ -156,11 +156,13 @@ namespace Impostor.Server.Net.State
             if (_compatibilityConfig.AllowVersionMixing == false &&
                 this.Host != null && client.GameVersion != this.Host.Client.GameVersion)
             {
-                if (client.GameVersion < this.Host.Client.GameVersion)
+                _compatibilityManager.TryGetCompatibilityGroup(client.GameVersion, out var clientCompatGroup);
+                _compatibilityManager.TryGetCompatibilityGroup(Host.Client.GameVersion, out var hostCompatGroup);
+                if (clientCompatGroup < hostCompatGroup)
                 {
                     return GameJoinResult.FromError(GameJoinError.ClientOutdated);
                 }
-                else
+                else if (clientCompatGroup > hostCompatGroup)
                 {
                     return GameJoinResult.FromError(GameJoinError.ClientTooNew);
                 }

--- a/src/Impostor.Server/Net/State/Game.Incoming.cs
+++ b/src/Impostor.Server/Net/State/Game.Incoming.cs
@@ -156,15 +156,10 @@ namespace Impostor.Server.Net.State
             if (_compatibilityConfig.AllowVersionMixing == false &&
                 this.Host != null && client.GameVersion != this.Host.Client.GameVersion)
             {
-                _compatibilityManager.TryGetCompatibilityGroup(client.GameVersion, out var clientCompatGroup);
-                _compatibilityManager.TryGetCompatibilityGroup(Host.Client.GameVersion, out var hostCompatGroup);
-                if (clientCompatGroup < hostCompatGroup)
+                var versionCheckResult = _compatibilityManager.CanJoinGame(Host.Client.GameVersion, client.GameVersion);
+                if (versionCheckResult != GameJoinError.None)
                 {
-                    return GameJoinResult.FromError(GameJoinError.ClientOutdated);
-                }
-                else if (clientCompatGroup > hostCompatGroup)
-                {
-                    return GameJoinResult.FromError(GameJoinError.ClientTooNew);
+                    return GameJoinResult.FromError(versionCheckResult);
                 }
             }
 

--- a/src/Impostor.Server/Net/State/Game.Outgoing.cs
+++ b/src/Impostor.Server/Net/State/Game.Outgoing.cs
@@ -83,8 +83,7 @@ namespace Impostor.Server.Net.State
                 .Select(x => x.Value)
                 .ToArray();
 
-            // TODO: clean up post20220202 when versions before it are no longer supported.
-            Message07JoinedGameS2C.Serialize(message, clear, Code, player.Client.Id, HostId, players, player.Client.GameVersion >= GameVersion.GetVersion(2022, 2, 2));
+            Message07JoinedGameS2C.Serialize(message, clear, Code, player.Client.Id, HostId, players);
         }
 
         private void WriteAlterGameMessage(IMessageWriter message, bool clear, bool isPublic)

--- a/src/Impostor.Server/Net/State/Game.cs
+++ b/src/Impostor.Server/Net/State/Game.cs
@@ -12,6 +12,7 @@ using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Innersloth.GameOptions;
 using Impostor.Api.Net;
+using Impostor.Api.Net.Manager;
 using Impostor.Api.Net.Messages.S2C;
 using Impostor.Server.Events;
 using Impostor.Server.Net.Manager;
@@ -29,6 +30,7 @@ namespace Impostor.Server.Net.State
         private readonly ConcurrentDictionary<int, ClientPlayer> _players;
         private readonly HashSet<IPAddress> _bannedIps;
         private readonly IEventManager _eventManager;
+        private readonly ICompatibilityManager _compatibilityManager;
         private readonly CompatibilityConfig _compatibilityConfig;
         private readonly TimeoutConfig _timeoutConfig;
 
@@ -42,6 +44,7 @@ namespace Impostor.Server.Net.State
             GameFilterOptions filterOptions,
             ClientManager clientManager,
             IEventManager eventManager,
+            ICompatibilityManager compatibilityManager,
             IOptions<CompatibilityConfig> compatibilityConfig,
             IOptions<TimeoutConfig> timeoutConfig)
         {
@@ -60,6 +63,7 @@ namespace Impostor.Server.Net.State
             FilterOptions = filterOptions;
             _clientManager = clientManager;
             _eventManager = eventManager;
+            _compatibilityManager = compatibilityManager;
             _compatibilityConfig = compatibilityConfig.Value;
             _timeoutConfig = timeoutConfig.Value;
             Items = new ConcurrentDictionary<object, object>();

--- a/src/Impostor.Server/Program.cs
+++ b/src/Impostor.Server/Program.cs
@@ -101,6 +101,7 @@ namespace Impostor.Server
                     services.Configure<ServerConfig>(host.Configuration.GetSection(ServerConfig.Section));
                     services.Configure<TimeoutConfig>(host.Configuration.GetSection(TimeoutConfig.Section));
 
+                    services.AddSingleton<ICompatibilityManager, CompatibilityManager>();
                     services.AddSingleton<ClientManager>();
                     services.AddSingleton<IClientManager>(p => p.GetRequiredService<ClientManager>());
 

--- a/src/Impostor.Server/Recorder/ClientRecorder.cs
+++ b/src/Impostor.Server/Recorder/ClientRecorder.cs
@@ -18,7 +18,7 @@ namespace Impostor.Server.Recorder
         private bool _createdGame;
         private bool _recordAfter;
 
-        public ClientRecorder(ILogger<Client> logger, IOptions<AntiCheatConfig> antiCheatOptions, ClientManager clientManager, ICustomMessageManager<ICustomRootMessage> customMessageManager, GameManager gameManager, string name, int gameVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData, HazelConnection connection, PacketRecorder recorder)
+        public ClientRecorder(ILogger<Client> logger, IOptions<AntiCheatConfig> antiCheatOptions, ClientManager clientManager, ICustomMessageManager<ICustomRootMessage> customMessageManager, GameManager gameManager, string name, GameVersion gameVersion, Language language, QuickChatModes chatMode, PlatformSpecificData platformSpecificData, HazelConnection connection, PacketRecorder recorder)
             : base(logger, antiCheatOptions, clientManager, gameManager, customMessageManager, name, gameVersion, language, chatMode, platformSpecificData, connection)
         {
             _recorder = recorder;

--- a/src/Impostor.Server/Recorder/PacketRecorder.cs
+++ b/src/Impostor.Server/Recorder/PacketRecorder.cs
@@ -194,7 +194,7 @@ namespace Impostor.Server.Recorder
                 context.Writer.Write(addressBytes);
                 context.Writer.Write((ushort)address.Port);
                 context.Writer.Write(client.Name);
-                context.Writer.Write(client.GameVersion);
+                context.Writer.Write(client.GameVersion.Value);
             }
         }
 

--- a/src/Impostor.Tests/CompatibilityManagerTests.cs
+++ b/src/Impostor.Tests/CompatibilityManagerTests.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Linq;
+using Impostor.Api.Games;
+using Impostor.Api.Innersloth;
+using Impostor.Api.Net.Manager;
+using Impostor.Server.Net.Manager;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Impostor.Tests;
+
+using CompatibilityGroup = ICompatibilityManager.CompatibilityGroup;
+using VersionCompareResult = ICompatibilityManager.VersionCompareResult;
+
+public sealed class CompatibilityManagerTests
+{
+    private static readonly CompatibilityGroup[] DefaultSupportedVersions =
+    {
+        new[]
+        {
+            new GameVersion(1, 0, 0),
+        },
+
+        new[]
+        {
+            new GameVersion(2, 0, 0),
+            new GameVersion(2, 1, 0),
+        },
+    };
+
+    private readonly CompatibilityManager _compatibilityManager = new(NullLogger<CompatibilityManager>.Instance, DefaultSupportedVersions);
+
+    public static IEnumerable<object[]> CanConnectToServerData =>
+        new List<object[]>
+        {
+            new object[] { VersionCompareResult.ClientTooOld, new GameVersion(0, 0, 0) },
+            new object[] { VersionCompareResult.ServerTooOld, new GameVersion(100, 0, 0) },
+            new object[] { VersionCompareResult.Unknown, new GameVersion(2, 0, 1) },
+        };
+
+    [Theory]
+    [MemberData(nameof(CanConnectToServerData))]
+    public void CanConnectToServer(VersionCompareResult versionCompareResult, GameVersion gameVersion)
+    {
+        Assert.Equal(versionCompareResult, _compatibilityManager.CanConnectToServer(gameVersion));
+    }
+
+    public static IEnumerable<object[]> CanJoinGameData =>
+        new List<object[]>
+        {
+            new object[] { GameJoinError.None, new GameVersion(1, 0, 0), new GameVersion(1, 0, 0) },
+            new object[] { GameJoinError.InvalidClient, new GameVersion(1, 0, 0), new GameVersion(100, 0, 0) },
+            new object[] { GameJoinError.ClientOutdated, new GameVersion(2, 0, 0), new GameVersion(1, 0, 0) },
+            new object[] { GameJoinError.ClientTooNew, new GameVersion(1, 0, 0), new GameVersion(2, 0, 0) },
+            new object[] { GameJoinError.None, new GameVersion(2, 0, 0), new GameVersion(2, 1, 0) },
+        };
+
+    [Theory]
+    [MemberData(nameof(CanJoinGameData))]
+    public void CanJoinGame(GameJoinError gameJoinError, GameVersion hostVersion, GameVersion clientVersion)
+    {
+        Assert.Equal(gameJoinError, _compatibilityManager.CanJoinGame(hostVersion, clientVersion));
+    }
+
+    public static IEnumerable<object[]> CanConnectAndJoinData =>
+        new List<object[]>
+        {
+            new object[] { new GameVersion(1, 0, 0), new GameVersion(1, 0, 0) },
+            new object[] { new GameVersion(2, 0, 0), new GameVersion(2, 0, 0) },
+            new object[] { new GameVersion(2, 1, 0), new GameVersion(2, 0, 0) },
+            new object[] { new GameVersion(2, 0, 0), new GameVersion(2, 1, 0) },
+            new object[] { new GameVersion(2, 0, 0), new GameVersion(2, 0, 0, 25) }, // server authority flag
+        };
+
+    [Theory]
+    [MemberData(nameof(CanConnectAndJoinData))]
+    public void CanConnectAndJoin(GameVersion hostVersion, GameVersion clientVersion)
+    {
+        Assert.Equal(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(hostVersion));
+        Assert.Equal(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(clientVersion));
+
+        Assert.Equal(GameJoinError.None, _compatibilityManager.CanJoinGame(hostVersion, clientVersion));
+    }
+
+    [Fact]
+    public void PublicApi()
+    {
+        ICompatibilityManager compatibilityManager = _compatibilityManager;
+
+        {
+            Assert.NotEqual(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(new GameVersion(2, 2, 0)));
+            Assert.NotEqual(GameJoinError.None, _compatibilityManager.CanJoinGame(new GameVersion(2, 2, 0), new GameVersion(2, 1, 0)));
+
+            var groupV2 = compatibilityManager.CompatibilityGroups.Single(g => g.GameVersions.Contains(new GameVersion(2, 0, 0)));
+            compatibilityManager.AddSupportedVersion(groupV2, new GameVersion(2, 2, 0));
+
+            Assert.Equal(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(new GameVersion(2, 2, 0)));
+            Assert.Equal(GameJoinError.None, _compatibilityManager.CanJoinGame(new GameVersion(2, 2, 0), new GameVersion(2, 1, 0)));
+        }
+
+        {
+            Assert.NotEqual(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(new GameVersion(3, 0, 0)));
+
+            compatibilityManager.AddCompatibilityGroup(new[] { new GameVersion(3, 0, 0), });
+
+            Assert.Equal(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(new GameVersion(3, 0, 0)));
+        }
+
+        {
+            Assert.Equal(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(new GameVersion(1, 0, 0)));
+
+            compatibilityManager.RemoveSupportedVersion(new GameVersion(1, 0, 0));
+
+            Assert.NotEqual(VersionCompareResult.Compatible, _compatibilityManager.CanConnectToServer(new GameVersion(1, 0, 0)));
+        }
+    }
+}

--- a/src/Impostor.Tests/GameVersionTests.cs
+++ b/src/Impostor.Tests/GameVersionTests.cs
@@ -1,0 +1,28 @@
+using Impostor.Api.Innersloth;
+using Xunit;
+
+namespace Impostor.Tests;
+
+public sealed class GameVersionTests
+{
+    [Theory]
+    [InlineData(50588150, 2023, 7, 11)]
+    [InlineData(50588175, 2023, 7, 11, 25)]
+    public void Test(int value, int year, int month, int day, int revision = 0)
+    {
+        var gameVersion = new GameVersion(year, month, day, revision);
+
+        Assert.Equal(value, gameVersion.Value);
+
+        gameVersion.GetComponents(out var parsedYear, out var parsedMonth, out var parsedDay, out var parsedRevision);
+        Assert.Equal(year, parsedYear);
+        Assert.Equal(month, parsedMonth);
+        Assert.Equal(day, parsedDay);
+        Assert.Equal(revision, parsedRevision);
+
+        Assert.Equal(year, gameVersion.Year);
+        Assert.Equal(month, gameVersion.Month);
+        Assert.Equal(day, gameVersion.Day);
+        Assert.Equal(revision, gameVersion.Revision);
+    }
+}

--- a/src/Impostor.Tools.ServerReplay/Program.cs
+++ b/src/Impostor.Tools.ServerReplay/Program.cs
@@ -165,7 +165,7 @@ namespace Impostor.Tools.ServerReplay
                     var addressPort = reader.ReadUInt16();
                     var address = new IPEndPoint(new IPAddress(addressBytes), addressPort);
                     var name = reader.ReadString();
-                    var gameVersion = reader.ReadInt32();
+                    var gameVersion = new GameVersion(reader.ReadInt32());
 
                     // Create and register connection.
                     var connection = new MockHazelConnection(address);

--- a/src/ProjectRules.ruleset
+++ b/src/ProjectRules.ruleset
@@ -12,6 +12,7 @@
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1111" Action="None" />
     <Rule Id="SA1128" Action="None" />
+    <Rule Id="SA1135" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.CSharp.NamingRules">
     <Rule Id="SA1309" Action="None" />


### PR DESCRIPTION
### Description

Official servers are allowing multiple game versions to crossplay. Impostor currently has a binary toggle that allows or forbids *all* crossplay. This PR adds the so-called CompatibiltyManager which puts all supported network versions in groups: if two versions are in the same group, they are allowed to play together.

This feature is also exposed as API so that plugins can mess this up on runtime without requiring server restarts every time Innersloth releases a small patch which bumps the network version but does not change the network protocol enough.

Also bump the minor version because we're introducing API and changing behaviour compared to previous versions.
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #532 
