### PR TITLE
Change default ListenIp of Http server to 0.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,6 @@ FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0
 WORKDIR /app
 COPY --from=build /app ./
 
-# Make the HttpServer listen to 0.0.0.0 to expose it to the outside world.
-ENV IMPOSTOR_HttpServer__ListenIp=0.0.0.0
 # Override ASPNETCORE_URLS to stop warning.
 ENV ASPNETCORE_URLS=
 

--- a/docs/Http-server.md
+++ b/docs/Http-server.md
@@ -4,8 +4,8 @@ Since Impostor 1.9.0 a HTTP service is included for matchmaking. Recent versions
 
 Depending on whether you want to support mobile players, you can set up the HTTP server in one of two ways:
 
-- Directly expose the HTTP server. Simpler, but only works if you don't want to support mobile players
-- Use a reverse proxy to expose the HTTP safer. More complex, but allows mobile players to connect
+- Directly expose the HTTP server. Simpler, but only works if you don't want to support mobile players.
+- Use a reverse proxy to expose the HTTP server. More complex, but allows mobile players to connect.
 
 ## Directly expose the HTTP server.
 
@@ -16,6 +16,8 @@ In config.json, set "ListenIp" to "0.0.0.0" in the "HttpServer" section. If you 
 A reverse proxy allows you to forward HTTP requests from users to multiple services. If you already have one, you should configure it to add Impostor. This page contains an Nginx configuration you can use for reference.
 
 If you have never set up a reverse proxy before, we recommend you to set up [Caddy](https://caddyserver.com/). It is easy to set up and comes with support for requesting SSL certificates out of the box.
+
+To prevent people from connecting directly to Impostor, we recommend changing the "ListenIp" in the "HttpServer" section to "127.0.0.1". This makes sure people can't connect to your HTTP server other than via your reverse proxy. Keep the "ListenIp" in the "Server" section at "0.0.0.0" though, running the normal game traffic through a proxy is not supported.
 
 ### Caddy
 

--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -34,7 +34,7 @@ Docker is a program that allows you to run programs like Impostor in a container
 After installing Docker, you can just start a Docker container with `docker run`:
 
 ```
-docker run -p 127.0.0.1:22023:22023/tcp -p 22023:22023/udp -e IMPOSTOR_Server__PublicIp=your.public.ip.here aeonlucid/impostor:nightly
+docker run -p 22023:22023/tcp -p 22023:22023/udp -e IMPOSTOR_Server__PublicIp=your.public.ip.here aeonlucid/impostor:nightly
 ```
 
 Please replace `your.public.ip.here` with the public IP address of your server. This is the address Among Us will try to reach your server at.
@@ -53,7 +53,7 @@ services:
     image: aeonlucid/impostor:nightly
     container_name: impostor
     ports:
-      - 127.0.0.1:22023:22023/tcp # Remove "127.0.0.1:" if you want to expose Impostor's HTTP server directly to the internet
+      - 22023:22023/tcp # Add "127.0.0.1:" if you're using a reverse proxy to terminate HTTPS
       - 22023:22023/udp
     environment: # Either configure Impostor using environment variables or mount a copy of config.json
       - IMPOSTOR_Server__PublicIp=your.public.ip.here

--- a/docs/Server-configuration.md
+++ b/docs/Server-configuration.md
@@ -17,11 +17,11 @@ Some information about all the possible configurations. Click [here](https://git
 
 Impostor has an Http Server that is used by recent versions of Among Us to connect to. See [the Http Server page](Http-server.md) for more details on how to set this up.
 
-| Key            | Default     | Description                                                                                                                                                                                  |
-|----------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Enabled**    | `true`      | Whether the http server should be enabled.                                                                                                                                                   |
-| **ListenIp**   | `127.0.0.1` | The network interface to listen on. Use `127.0.0.1` if you use a reverse proxy or just run locally. Use `0.0.0.0` if you are directly exposing this server to the internet (not recommended) |
-| **ListenPort** | `22023`     | The listen port of this server. For port forwarding purposes, this is an TCP port.                                                                                                           |
+| Key            | Default   | Description                                                                                                                                                                |
+|----------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Enabled**    | `true`    | Whether the http server should be enabled.                                                                                                                                 |
+| **ListenIp**   | `0.0.0.0` | The network interface to listen on. Use `127.0.0.1` if you use a reverse proxy or just run locally. Use `0.0.0.0` if you are directly exposing this server to the internet |
+| **ListenPort** | `22023`   | The listen port of this server. For port forwarding purposes, this is an TCP port.                                                                                         |
 
 ### AntiCheat
 

--- a/src/Impostor.Api/Config/HttpServerConfig.cs
+++ b/src/Impostor.Api/Config/HttpServerConfig.cs
@@ -16,8 +16,8 @@ public class HttpServerConfig
     /// Gets or sets the IP address the HTTP Matchmaking server will listen on.
     /// </summary>
     /// Use "127.0.0.1" if you are running behind a reverse proxy or just testing locally.
-    /// Use "0.0.0.0" if you are directly exposing this server to the internet (not recommended).
-    public string ListenIp { get; set; } = "127.0.0.1";
+    /// Use "0.0.0.0" if you are directly exposing this server to the internet.
+    public string ListenIp { get; set; } = "0.0.0.0";
 
     /// <summary>
     /// Gets or sets the port the HTTP Matchmaking server will listen on.

--- a/src/Impostor.Server/Net/MatchmakerService.cs
+++ b/src/Impostor.Server/Net/MatchmakerService.cs
@@ -12,15 +12,18 @@ namespace Impostor.Server.Net
     {
         private readonly ILogger<MatchmakerService> _logger;
         private readonly ServerConfig _serverConfig;
+        private readonly HttpServerConfig _httpServerConfig;
         private readonly Matchmaker _matchmaker;
 
         public MatchmakerService(
             ILogger<MatchmakerService> logger,
             IOptions<ServerConfig> serverConfig,
+            IOptions<HttpServerConfig> httpServerConfig,
             Matchmaker matchmaker)
         {
             _logger = logger;
             _serverConfig = serverConfig.Value;
+            _httpServerConfig = httpServerConfig.Value;
             _matchmaker = matchmaker;
         }
 
@@ -37,12 +40,18 @@ namespace Impostor.Server.Net
                 _serverConfig.ResolvePublicIp(),
                 _serverConfig.PublicPort);
 
-            // NOTE: If this warning annoys you, set your PublicIp to "localhost"
+            // Only show one warning to reduce warning fatigue
             if (_serverConfig.PublicIp == "127.0.0.1")
             {
-                _logger.LogWarning("Your PublicIp is set to the default value of 127.0.0.1.");
-                _logger.LogWarning("To allow people on other devices to connect to your server, change this value to your Public IP address");
-                _logger.LogWarning("For more info on how to do this see https://github.com/Impostor/Impostor/blob/master/docs/Server-configuration.md");
+                // NOTE: If this warning annoys you, set your PublicIp to "localhost"
+                _logger.LogError("Your PublicIp is set to the default value of 127.0.0.1.");
+                _logger.LogError("To allow people on other devices to connect to your server, change this value to your Public IP address");
+                _logger.LogError("For more info on how to do this see https://github.com/Impostor/Impostor/blob/master/docs/Server-configuration.md");
+            }
+            else if (_httpServerConfig.ListenIp == "0.0.0.0")
+            {
+                _logger.LogWarning("Your HTTP server is exposed to the public internet, we recommend setting up a reverse proxy and enabling HTTPS");
+                _logger.LogWarning("See https://github.com/Impostor/Impostor/blob/master/docs/Http-server.md for instructions");
             }
         }
 

--- a/src/Impostor.Server/Net/MatchmakerService.cs
+++ b/src/Impostor.Server/Net/MatchmakerService.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Impostor.Api.Config;
@@ -48,7 +49,8 @@ namespace Impostor.Server.Net
                 _logger.LogError("For more info on how to do this see https://github.com/Impostor/Impostor/blob/master/docs/Server-configuration.md");
             }
 
-            if (_httpServerConfig.ListenIp == "0.0.0.0")
+            var runningOutsideContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == null;
+            if (_httpServerConfig.ListenIp == "0.0.0.0" && runningOutsideContainer)
             {
                 _logger.LogWarning("Your HTTP server is exposed to the public internet, we recommend setting up a reverse proxy and enabling HTTPS");
                 _logger.LogWarning("See https://github.com/Impostor/Impostor/blob/master/docs/Http-server.md for instructions");

--- a/src/Impostor.Server/Net/MatchmakerService.cs
+++ b/src/Impostor.Server/Net/MatchmakerService.cs
@@ -40,7 +40,6 @@ namespace Impostor.Server.Net
                 _serverConfig.ResolvePublicIp(),
                 _serverConfig.PublicPort);
 
-            // Only show one warning to reduce warning fatigue
             if (_serverConfig.PublicIp == "127.0.0.1")
             {
                 // NOTE: If this warning annoys you, set your PublicIp to "localhost"
@@ -48,7 +47,8 @@ namespace Impostor.Server.Net
                 _logger.LogError("To allow people on other devices to connect to your server, change this value to your Public IP address");
                 _logger.LogError("For more info on how to do this see https://github.com/Impostor/Impostor/blob/master/docs/Server-configuration.md");
             }
-            else if (_httpServerConfig.ListenIp == "0.0.0.0")
+
+            if (_httpServerConfig.ListenIp == "0.0.0.0")
             {
                 _logger.LogWarning("Your HTTP server is exposed to the public internet, we recommend setting up a reverse proxy and enabling HTTPS");
                 _logger.LogWarning("See https://github.com/Impostor/Impostor/blob/master/docs/Http-server.md for instructions");

--- a/src/Impostor.Server/config-full.json
+++ b/src/Impostor.Server/config-full.json
@@ -7,7 +7,7 @@
   },
   "HttpServer": {
     "Enabled": true,
-    "ListenIp": "127.0.0.1",
+    "ListenIp": "0.0.0.0",
     "ListenPort": 22023
   },
   "AntiCheat": {

--- a/src/Impostor.Server/config.json
+++ b/src/Impostor.Server/config.json
@@ -7,7 +7,7 @@
   },
   "HttpServer": {
     "Enabled": true,
-    "ListenIp": "127.0.0.1",
+    "ListenIp": "0.0.0.0",
     "ListenPort": 22023
   },
   "AntiCheat": {


### PR DESCRIPTION
We see that a lot of support tickets are caused by this default setting, as it is one of the things that blocks connections to the server with no obvious indication that this is happening. To make it easier for first time users to set up Impostor, it is important that this setting is changed.

Previously we also recommended against direct exposing due to security reasons, but I believe this fear to be unfounded: Microsoft claims that the Kestrel server is hardened against web server vulnerabilities and supports its use both with and without a reverse proxy.[1]

We still recommend using reverse proxies if HTTPS support is needed, so that section of documentation still remains. Setting the ListenIp to 127.0.0.1 is still recommended when using a reverse proxy to remove the ability for people to connect directly, so we add it there as a recommendation.

[1]: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/when-to-use-a-reverse-proxy?view=aspnetcore-8.0
