### PR TITLE
Don't set HTTP protocols explicitly

### DIFF
--- a/src/Impostor.Server/Program.cs
+++ b/src/Impostor.Server/Program.cs
@@ -230,10 +230,7 @@ namespace Impostor.Server
 
                     builder.ConfigureKestrel(serverOptions =>
                     {
-                        serverOptions.Listen(IPAddress.Parse(httpConfig.ListenIp), httpConfig.ListenPort, listenOptions =>
-                        {
-                            listenOptions.Protocols = HttpProtocols.Http1AndHttp2;
-                        });
+                        serverOptions.Listen(IPAddress.Parse(httpConfig.ListenIp), httpConfig.ListenPort);
                     });
                 });
             }

--- a/src/Impostor.Server/Program.cs
+++ b/src/Impostor.Server/Program.cs
@@ -25,7 +25,6 @@ using Impostor.Server.Recorder;
 using Impostor.Server.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
We don't support built-in HTTPS anymore so let kestrel default to HTTP1 only.
> HTTP/2 is not enabled for 127.0.0.1:22023. The endpoint is configured to use HTTP/1.1 and HTTP/2, but TLS is not enabled. HTTP/2 requires TLS application protocol negotiation. Connections to this endpoint will use HTTP/1.1.