### PR TITLE
Add Host property to IGameCreatedEvent

### DIFF
--- a/src/Impostor.Api/Events/Game/IGameCreatedEvent.cs
+++ b/src/Impostor.Api/Events/Game/IGameCreatedEvent.cs
@@ -1,11 +1,24 @@
 ﻿using Impostor.Api.Games;
+using Impostor.Api.Net;
 
 namespace Impostor.Api.Events
 {
     /// <summary>
     ///     Called whenever a new <see cref="IGame" /> is created.
     /// </summary>
+    /// <remarks>
+    ///     Note that the game just has been created, so no players have joined
+    ///     it yet. If you want to know the future host of this game, use the
+    ///     <see cref="Host"/> property.
+    /// </remarks>
     public interface IGameCreatedEvent : IGameEvent
     {
+        /// <summary>
+        ///     Gets the client that requested creation of the game.
+        /// </summary>
+        /// <remarks>
+        ///     Will be null if game creation was requested by a plugin.
+        /// </remarks>
+        IClient? Host { get; }
     }
 }

--- a/src/Impostor.Server/Events/Game/GameCreatedEvent.cs
+++ b/src/Impostor.Server/Events/Game/GameCreatedEvent.cs
@@ -1,15 +1,19 @@
 ﻿using Impostor.Api.Events;
 using Impostor.Api.Games;
+using Impostor.Api.Net;
 
 namespace Impostor.Server.Events
 {
     public class GameCreatedEvent : IGameCreatedEvent
     {
-        public GameCreatedEvent(IGame game)
+        public GameCreatedEvent(IGame game, IClient? host)
         {
             Game = game;
+            Host = host;
         }
 
         public IGame Game { get; }
+
+        public IClient? Host { get; }
     }
 }

--- a/src/Impostor.Server/Net/Manager/GameManager.cs
+++ b/src/Impostor.Server/Net/Manager/GameManager.cs
@@ -93,11 +93,11 @@ namespace Impostor.Server.Net.Manager
                 return null;
             }
 
-            var (success, game) = await TryCreateAsync(options, filterOptions, @event.GameCode);
+            var (success, game) = await TryCreateAsync(options, filterOptions, owner, @event.GameCode);
 
             for (var i = 0; i < 10 && !success; i++)
             {
-                (success, game) = await TryCreateAsync(options, filterOptions);
+                (success, game) = await TryCreateAsync(options, filterOptions, owner);
             }
 
             if (!success || game == null)
@@ -113,7 +113,7 @@ namespace Impostor.Server.Net.Manager
             return CreateAsync(null, options, filterOptions);
         }
 
-        private async ValueTask<(bool Success, Game? Game)> TryCreateAsync(IGameOptions options, GameFilterOptions filterOptions, GameCode? desiredGameCode = null)
+        private async ValueTask<(bool Success, Game? Game)> TryCreateAsync(IGameOptions options, GameFilterOptions filterOptions, IClient? owner, GameCode? desiredGameCode = null)
         {
             var gameCode = desiredGameCode ?? _gameCodeFactory.Create();
             var game = ActivatorUtilities.CreateInstance<Game>(_serviceProvider, _publicIp, gameCode, options, filterOptions);
@@ -125,7 +125,7 @@ namespace Impostor.Server.Net.Manager
 
             _logger.LogDebug("Created game with code {0}.", game.Code);
 
-            await _eventManager.CallAsync(new GameCreatedEvent(game));
+            await _eventManager.CallAsync(new GameCreatedEvent(game, owner));
 
             return (true, game);
         }


### PR DESCRIPTION
When a game has just been created, it does not yet have any players in them, and as a result you can't get the host or its connection id when this event is called. This makes it annoying to link between this event and the IGameCreationEvent that came just before it.

Having this link is useful for the usecase of a game code allocation plugin that allocates codes from a pool, and needs to return codes to a pool if these codes weren't picked.
