### PR TITLE
Clean up clients that refuse to quit properly

### DIFF
--- a/src/Impostor.Server/Net/State/Game.State.cs
+++ b/src/Impostor.Server/Net/State/Game.State.cs
@@ -81,7 +81,7 @@ namespace Impostor.Server.Net.State
                 if (player.Client.Connection.IsConnected && player.Client.Connection is HazelConnection hazel)
                 {
                     _logger.LogInformation("{0} - Player {1} ({2}) kept connection open after leaving, disposing.", Code, player.Client.Name, playerId);
-                    hazel.DisposeInnerConnection();
+                    await player.Client.DisconnectAsync(isBan ? DisconnectReason.Banned : DisconnectReason.Kicked);
                 }
             });
 


### PR DESCRIPTION
When a player is kicked or banned from a game, the client is expected to disconnect in response. When they decide not to *or* the disconnect packet is lost, Impostor just silently disposes of the connection. This does not remove them from ClientManager, which is how I tracked this bug down.

By sending them a proper disconnect message, clients should have received *a* disconnection message before dropping their connection.

Future work should split this entire method in removing players from a game and processing kick/bans because the latter feature is not relevant for other callers of this method.

