### PR TITLE
Accept RPC's called on GameManager

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/GameManager/Logic/GameLogicComponent.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/GameManager/Logic/GameLogicComponent.cs
@@ -6,9 +6,9 @@ namespace Impostor.Server.Net.Inner.Objects.GameManager.Logic;
 
 internal abstract class GameLogicComponent
 {
-    public virtual ValueTask HandleRpcAsync(RpcCalls callId, IMessageReader reader)
+    public virtual ValueTask<bool> HandleRpcAsync(RpcCalls callId, IMessageReader reader)
     {
-        throw new NotImplementedException($"Unhandled RpcCall {callId}");
+        return ValueTask.FromResult(false);
     }
 
     public virtual ValueTask<bool> SerializeAsync(IMessageWriter writer, bool initialState)


### PR DESCRIPTION

### Description

Previously Impostor would just throw when a method was called on a GameManager, but this caused issues with client mods that did just this, even through vanilla never calls an RPC on GameManager.

This commit changes that throw statement to pass the exception to the custom message handler/anticheat instead, which is also how it works for the other NetObjects

<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- Fixed 25 exceptions caused by various mods on my server in my logging window
