### PR TITLE
Improve CompatMgr behaviour for unknown versions

### DIFF
--- a/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
+++ b/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
@@ -63,6 +63,12 @@ internal class CompatibilityManager : ICompatibilityManager
         return null;
     }
 
+    private CompatibilityGroup GetCompatibilityGroupOrDefault(GameVersion clientVersion)
+    {
+        // If the compatibility group is not defined, we assume it is not compatible with anything else than itself
+        return TryGetCompatibilityGroup(clientVersion) ?? new CompatibilityGroup(new[] { clientVersion.Normalize() });
+    }
+
     public VersionCompareResult CanConnectToServer(GameVersion clientVersion)
     {
         if (this.TryGetCompatibilityGroup(clientVersion) != null)
@@ -91,13 +97,8 @@ internal class CompatibilityManager : ICompatibilityManager
             return GameJoinError.None;
         }
 
-        var hostCompatGroup = this.TryGetCompatibilityGroup(hostVersion);
-        var playerCompatGroup = this.TryGetCompatibilityGroup(clientVersion);
-
-        if (hostCompatGroup == null || playerCompatGroup == null)
-        {
-            return GameJoinError.InvalidClient;
-        }
+        var hostCompatGroup = GetCompatibilityGroupOrDefault(hostVersion);
+        var playerCompatGroup = GetCompatibilityGroupOrDefault(clientVersion);
 
         if (hostCompatGroup != playerCompatGroup)
         {

--- a/src/Impostor.Tests/CompatibilityManagerTests.cs
+++ b/src/Impostor.Tests/CompatibilityManagerTests.cs
@@ -48,11 +48,23 @@ public sealed class CompatibilityManagerTests
     public static IEnumerable<object[]> CanJoinGameData =>
         new List<object[]>
         {
+            // Same version -> can join
             new object[] { GameJoinError.None, new GameVersion(1, 0, 0), new GameVersion(1, 0, 0) },
-            new object[] { GameJoinError.InvalidClient, new GameVersion(1, 0, 0), new GameVersion(100, 0, 0) },
+
+            // Compatible versions -> can join
+            new object[] { GameJoinError.None, new GameVersion(2, 0, 0), new GameVersion(2, 1, 0) },
+
+            // Different incompatible versions -> show correct error
             new object[] { GameJoinError.ClientOutdated, new GameVersion(2, 0, 0), new GameVersion(1, 0, 0) },
             new object[] { GameJoinError.ClientTooNew, new GameVersion(1, 0, 0), new GameVersion(2, 0, 0) },
-            new object[] { GameJoinError.None, new GameVersion(2, 0, 0), new GameVersion(2, 1, 0) },
+
+            // Versions unknown to Impostor -> also show correct errors
+            new object[] { GameJoinError.ClientTooNew, new GameVersion(0, 0, 1), new GameVersion(1, 0, 0) },
+            new object[] { GameJoinError.ClientOutdated, new GameVersion(1, 0, 0), new GameVersion(0, 0, 1) },
+            new object[] { GameJoinError.ClientTooNew, new GameVersion(1, 0, 0), new GameVersion(100, 0, 0) },
+            new object[] { GameJoinError.ClientOutdated, new GameVersion(100, 0, 0), new GameVersion(1, 0, 0) },
+            new object[] { GameJoinError.ClientTooNew, new GameVersion(0, 0, 1), new GameVersion(100, 0, 0) },
+
         };
 
     [Theory]


### PR DESCRIPTION
### Description

Currently, Impostor will show an "Client is in an invalid state." message if a player tries to join a match where the host or the joining player is using a version unknown to Impostor.

This message confused a *lot* of people, so this PR changes the API such that if the version is not registered, the version itself is put in a compatibility group and compared, assuming no other game versions are compatible with it. This works fine in most cases, as Among Us network versions generally increase over time.

Failure on 2222.2.2 (which is ancient at this point, so likely no longer used) and future cases where Innersloth messes up (which is unlikely) is an acceptable consequence to me.
