### PR TITLE
ProtocolExtensions mode + setting

### DIFF
--- a/src/Impostor.Api/Config/AntiCheatConfig.cs
+++ b/src/Impostor.Api/Config/AntiCheatConfig.cs
@@ -1,4 +1,4 @@
-﻿namespace Impostor.Api.Config
+namespace Impostor.Api.Config
 {
     public class AntiCheatConfig
     {
@@ -24,6 +24,6 @@
 
         public bool EnableTargetChecks { get; set; } = true;
 
-        public bool ForbidProtocolExtensions { get; set; } = true;
+        public ProtocolExtensionsMode AllowProtocolExtensions { get; set; } = ProtocolExtensionsMode.Never;
     }
 }

--- a/src/Impostor.Api/Config/ProtocolExtensionsMode.cs
+++ b/src/Impostor.Api/Config/ProtocolExtensionsMode.cs
@@ -1,0 +1,28 @@
+namespace Impostor.Api.Config
+{
+    /// <summary>
+    /// Details if exceptions are made for protocol extensions.
+    /// </summary>
+    public enum ProtocolExtensionsMode
+    {
+        /// <summary>
+        /// Always forbid protocol extensions.
+        /// </summary>
+        Never,
+
+        /// <summary>
+        /// Protocol extensions is always needed if host request authority.
+        /// </summary>
+        /// <para>
+        /// HostAuthority can be requested by hosts by adding 25 to their patch
+        /// version when connecting. This flag is used by a lot of (host-only)
+        /// mods and also disable server authority over MurderPlayer packets.
+        /// </para>
+        IfRequested,
+
+        /// <summary>
+        /// Protocol extensions is always allowed.
+        /// </summary>
+        Always,
+    }
+}

--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -65,7 +65,13 @@ namespace Impostor.Server.Net
 
             var isCategoryEnabled = category switch
             {
-                CheatCategory.ProtocolExtension => _antiCheatConfig.ForbidProtocolExtensions,
+                CheatCategory.ProtocolExtension => _antiCheatConfig.AllowProtocolExtensions switch
+                {
+                    ProtocolExtensionsMode.Always => false,
+                    ProtocolExtensionsMode.IfRequested => !GameVersion.HasDisableServerAuthorityFlag,
+                    ProtocolExtensionsMode.Never => true,
+                    _ => true,
+                },
                 CheatCategory.GameFlow => _antiCheatConfig.EnableGameFlowChecks,
                 CheatCategory.MustBeHost => _antiCheatConfig.EnableMustBeHostChecks,
                 CheatCategory.ColorLimits => _antiCheatConfig.EnableColorLimitChecks,


### PR DESCRIPTION
Simply setting this setting as true or false is not a good practice.
We can decide this based on host authority. Any mod that uses protocol extensions should have +25 flags