### PR TITLE
Refactor SetColor anticheat

### DIFF
--- a/src/Impostor.Server/Net/State/Game.cs
+++ b/src/Impostor.Server/Net/State/Game.cs
@@ -9,8 +9,10 @@ using Impostor.Api.Config;
 using Impostor.Api.Events.Managers;
 using Impostor.Api.Games;
 using Impostor.Api.Innersloth;
+using Impostor.Api.Innersloth.Customization;
 using Impostor.Api.Innersloth.GameOptions;
 using Impostor.Api.Net;
+using Impostor.Api.Net.Inner.Objects;
 using Impostor.Api.Net.Manager;
 using Impostor.Api.Net.Messages.S2C;
 using Impostor.Server.Events;
@@ -129,6 +131,15 @@ namespace Impostor.Server.Net.State
 
                 await _eventManager.CallAsync(new GameStartedEvent(this));
             }
+        }
+
+        /// <summary>Check if there are players using a color.</summary>
+        /// <param name="color">The color to check for.</param>
+        /// <param name="exceptBy">Exempt a player from being checked.</param>
+        /// <returns>True if there is player other than exceptBy that uses that color.</returns>
+        internal bool IsColorUsed(ColorType color, IInnerPlayerControl? exceptBy = null)
+        {
+            return Players.Any(p => p.Character != null && p.Character != exceptBy && p.Character.PlayerInfo.CurrentOutfit.Color == color);
         }
 
         private ValueTask BroadcastJoinMessage(IMessageWriter message, bool clear, ClientPlayer player)


### PR DESCRIPTION
### Description

One issue with the ColorLimits checks is that it didn't account for mods that add extra colors, this is fixed by checking if the route followed is plausible instead of mimicking client logic and only accepting a single answer that it expected. A false negative is possible where the host decides to wrap back to the front but there are still custom colors available at the end of the list. This is acceptable because Impostor doesn't currently know the amount of colors available and this issue isn't major enough to ask all mod authors to declare their custom color amount to the server.

As extra colors should now be handled by this code, it makes sense to change the category of the unknown colors check to ProtocolExtensions. For these mods an exemption of the ColorLimits category is no longer necessary.

Note that mods that allow duplicate colors that do not use a custom rpc to set colors can only be supported by disabling the ColorLimits category, this was already the case and I don't think it can be unified with the existing check.


