### PR TITLE
Add Sequence ID and Dirty tracking to PlayerOutfit

### DIFF
--- a/src/Impostor.Api/Innersloth/Customization/PlayerOutfit.cs
+++ b/src/Impostor.Api/Innersloth/Customization/PlayerOutfit.cs
@@ -2,6 +2,8 @@ namespace Impostor.Api.Innersloth.Customization
 {
     public class PlayerOutfit
     {
+        public string PlayerName { get; internal set; } = string.Empty;
+
         public ColorType Color { get; internal set; } = (ColorType)(-1);
 
         public string HatId { get; internal set; } = "missing";
@@ -14,7 +16,15 @@ namespace Impostor.Api.Innersloth.Customization
 
         public string NamePlateId { get; internal set; } = "missing";
 
-        public string PlayerName { get; internal set; } = "missing";
+        private byte HatSequenceId { get; set; } = 0;
+
+        private byte PetSequenceId { get; set; } = 0;
+
+        private byte SkinSequenceId { get; set; } = 0;
+
+        private byte VisorSequenceId { get; set; } = 0;
+
+        private byte NamePlateSequenceId { get; set; } = 0;
 
         public bool IsIncomplete
         {
@@ -38,6 +48,11 @@ namespace Impostor.Api.Innersloth.Customization
             writer.Write(SkinId);
             writer.Write(VisorId);
             writer.Write(NamePlateId);
+            writer.Write(HatSequenceId);
+            writer.Write(PetSequenceId);
+            writer.Write(SkinSequenceId);
+            writer.Write(VisorSequenceId);
+            writer.Write(NamePlateSequenceId);
         }
 
         public void Deserialize(IMessageReader reader)
@@ -49,6 +64,11 @@ namespace Impostor.Api.Innersloth.Customization
             SkinId = reader.ReadString();
             VisorId = reader.ReadString();
             NamePlateId = reader.ReadString();
+            HatSequenceId = reader.ReadByte();
+            PetSequenceId = reader.ReadByte();
+            SkinSequenceId = reader.ReadByte();
+            VisorSequenceId = reader.ReadByte();
+            NamePlateSequenceId = reader.ReadByte();
         }
     }
 }

--- a/src/Impostor.Api/Innersloth/Customization/PlayerOutfit.cs
+++ b/src/Impostor.Api/Innersloth/Customization/PlayerOutfit.cs
@@ -2,19 +2,57 @@ namespace Impostor.Api.Innersloth.Customization
 {
     public class PlayerOutfit
     {
-        public string PlayerName { get; internal set; } = string.Empty;
+        private string _playerName = string.Empty;
+        private ColorType _color = (ColorType)(-1);
+        private string _hatId = "missing";
+        private string _petId = "missing";
+        private string _skinId = "missing";
+        private string _visorId = "missing";
+        private string _namePlateId = "missing";
 
-        public ColorType Color { get; internal set; } = (ColorType)(-1);
+        public bool IsDirty { get; internal set; }
 
-        public string HatId { get; internal set; } = "missing";
+        public string PlayerName
+        {
+            get => _playerName;
+            internal set => SetField(ref _playerName, value);
+        }
 
-        public string PetId { get; internal set; } = "missing";
+        public ColorType Color
+        {
+            get => _color;
+            internal set => SetField(ref _color, value);
+        }
 
-        public string SkinId { get; internal set; } = "missing";
+        public string HatId
+        {
+            get => _hatId;
+            internal set => SetField(ref _hatId, value);
+        }
 
-        public string VisorId { get; internal set; } = "missing";
+        public string PetId
+        {
+            get => _petId;
+            internal set => SetField(ref _petId, value);
+        }
 
-        public string NamePlateId { get; internal set; } = "missing";
+        public string SkinId
+        {
+            get => _skinId;
+            internal set => SetField(ref _skinId, value);
+        }
+
+        public string VisorId
+        {
+            get => _visorId;
+            internal set => SetField(ref _visorId, value);
+        }
+
+        public string NamePlateId
+        {
+            get => _namePlateId;
+            internal set => SetField(ref _namePlateId, value);
+        }
 
         private byte HatSequenceId { get; set; } = 0;
 
@@ -69,6 +107,12 @@ namespace Impostor.Api.Innersloth.Customization
             SkinSequenceId = reader.ReadByte();
             VisorSequenceId = reader.ReadByte();
             NamePlateSequenceId = reader.ReadByte();
+        }
+
+        private void SetField<T>(ref T field, T value)
+        {
+            field = value;
+            IsDirty = true;
         }
     }
 }


### PR DESCRIPTION
### Description

2024.6.18 adds SequenceId's to player outfits. They're currently unused and that seems to work Just Fine as long as only one player is setting cosmetics. This will probably need a follow-up PR in future.

As we need to send over the new outfit when a change occurs, implement change tracking. To prevent unnecessary code duplication, this is done using a helper method.
