### PR TITLE
Demote InnerGameData, promote InnerPlayerInfo

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/IInnerGameData.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerGameData.cs
@@ -1,6 +1,6 @@
 ﻿namespace Impostor.Api.Net.Inner.Objects
 {
-    public interface IInnerGameData : IInnerNetObject
+    public interface IInnerGameData
     {
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerGameData.cs
@@ -1,36 +1,12 @@
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Impostor.Api;
-using Impostor.Api.Events.Managers;
-using Impostor.Api.Net;
-using Impostor.Api.Net.Custom;
-using Impostor.Api.Net.Inner;
 using Impostor.Api.Net.Inner.Objects;
-using Impostor.Api.Net.Messages.Rpcs;
-using Impostor.Server.Net.Inner.Objects.Components;
-using Impostor.Server.Net.State;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Impostor.Server.Net.Inner.Objects
 {
-    internal partial class InnerGameData : InnerNetObject, IInnerGameData
+    internal partial class InnerGameData : IInnerGameData
     {
-        private readonly ILogger<InnerGameData> _logger;
-        private readonly IEventManager _eventManager;
-        private readonly ConcurrentDictionary<byte, InnerPlayerInfo> _allPlayers;
-
-        public InnerGameData(ICustomMessageManager<ICustomRpc> customMessageManager, Game game, ILogger<InnerGameData> logger, IEventManager eventManager, IServiceProvider serviceProvider) : base(customMessageManager, game)
-        {
-            _logger = logger;
-            _eventManager = eventManager;
-            _allPlayers = new ConcurrentDictionary<byte, InnerPlayerInfo>();
-
-            Components.Add(this);
-            Components.Add(ActivatorUtilities.CreateInstance<InnerVoteBanSystem>(serviceProvider, game));
-        }
+        private readonly ConcurrentDictionary<byte, InnerPlayerInfo> _allPlayers = new();
 
         public int PlayerCount => _allPlayers.Count;
 
@@ -46,103 +22,14 @@ namespace Impostor.Server.Net.Inner.Objects
             return _allPlayers.TryGetValue(id, out var player) ? player : null;
         }
 
-        public override ValueTask<bool> SerializeAsync(IMessageWriter writer, bool initialState)
+        internal bool AddPlayer(InnerPlayerInfo playerInfo)
         {
-            throw new NotImplementedException();
+            return _allPlayers.TryAdd(playerInfo.PlayerId, playerInfo);
         }
 
-        public override async ValueTask DeserializeAsync(IClientPlayer sender, IClientPlayer? target, IMessageReader reader, bool initialState)
+        internal void RemovePlayer(byte playerId)
         {
-            if (!await ValidateHost(CheatContext.Deserialize, sender))
-            {
-                return;
-            }
-
-            while (reader.Position < reader.Length)
-            {
-                var inner = reader.ReadMessage();
-                var playerInfo = this.GetPlayerById(inner.Tag);
-                if (playerInfo != null)
-                {
-                    playerInfo.Deserialize(inner);
-                }
-                else
-                {
-                    playerInfo = new InnerPlayerInfo(inner.Tag);
-                    playerInfo.Deserialize(inner);
-
-                    if (!_allPlayers.TryAdd(playerInfo.PlayerId, playerInfo))
-                    {
-                        throw new ImpostorException("Failed to add player to InnerGameData.");
-                    }
-                }
-            }
-        }
-
-        public override async ValueTask<bool> HandleRpcAsync(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
-        {
-            if (!await ValidateHost(call, sender))
-            {
-                return false;
-            }
-
-            switch (call)
-            {
-                case RpcCalls.SetTasks:
-                {
-                    Rpc29SetTasks.Deserialize(reader, out var playerId, out var taskTypeIds);
-                    SetTasks(playerId, taskTypeIds);
-                    break;
-                }
-
-                default:
-                    return await base.HandleRpcAsync(sender, target, call, reader);
-            }
-
-            return true;
-        }
-
-        internal InnerPlayerInfo? AddPlayer(InnerPlayerControl control)
-        {
-            var playerId = control.PlayerId;
-            var playerInfo = new InnerPlayerInfo(control.PlayerId);
-
-            if (_allPlayers.TryAdd(playerId, playerInfo))
-            {
-                return playerInfo;
-            }
-
-            return null;
-        }
-
-        internal void RemovePlayer(InnerPlayerControl control)
-        {
-            _allPlayers.TryRemove(control.PlayerInfo.PlayerId, out _);
-        }
-
-        private void SetTasks(byte playerId, ReadOnlyMemory<byte> taskTypeIds)
-        {
-            var player = GetPlayerById(playerId);
-            if (player == null)
-            {
-                _logger.LogTrace("Could not set tasks for playerId {0}.", playerId);
-                return;
-            }
-
-            if (player.Disconnected)
-            {
-                return;
-            }
-
-            player.Tasks = new List<TaskInfo>(taskTypeIds.Length);
-
-            var taskId = 0u;
-            foreach (var taskTypeId in taskTypeIds.Span)
-            {
-                var mapTasks = Game.GameNet!.ShipStatus?.Data.Tasks;
-                var taskType = (mapTasks != null && mapTasks.ContainsKey(taskTypeId)) ? mapTasks[taskTypeId] : null;
-                player.Tasks.Add(new TaskInfo(player, _eventManager, taskId++, taskType));
-            }
+            _allPlayers.TryRemove(playerId, out _);
         }
     }
 }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.Api.cs
@@ -3,7 +3,7 @@ using Impostor.Api.Net.Inner.Objects;
 
 namespace Impostor.Server.Net.Inner.Objects
 {
-    internal partial class InnerPlayerInfo : IInnerPlayerInfo
+    internal partial class InnerPlayerInfo : InnerNetObject, IInnerPlayerInfo
     {
         IEnumerable<ITaskInfo> IInnerPlayerInfo.Tasks => Tasks;
     }

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -35,7 +35,6 @@ namespace Impostor.Server.Net.State
             [0] = typeof(InnerSkeldShipStatus),
             [1] = typeof(InnerMeetingHud),
             [2] = typeof(InnerLobbyBehaviour),
-            [3] = typeof(InnerGameData),
             [4] = typeof(InnerPlayerControl),
             [5] = typeof(InnerMiraShipStatus),
             [6] = typeof(InnerPolusShipStatus),
@@ -43,6 +42,8 @@ namespace Impostor.Server.Net.State
             [8] = typeof(InnerAirshipStatus),
             [9] = typeof(InnerHideAndSeekManager),
             [10] = typeof(InnerNormalGameManager),
+            [11] = typeof(InnerPlayerInfo),
+            [12] = typeof(InnerVoteBanSystem),
             [13] = typeof(InnerFungleShipStatus),
         };
 
@@ -325,9 +326,17 @@ namespace Impostor.Server.Net.State
                     break;
                 }
 
-                case InnerGameData data:
+                case InnerPlayerInfo playerInfo:
                 {
-                    GameNet.GameData = data;
+                    if (!GameNet.GameData.AddPlayer(playerInfo))
+                    {
+                        _logger.LogWarning(
+                            "Could not add PlayerInfo for playerId {PlayerId} with NetId {newId}, already have NetId {oldNetId}",
+                            playerInfo.PlayerId,
+                            playerInfo.NetId,
+                            GameNet.GameData.GetPlayerById(playerInfo.PlayerId)?.NetId);
+                    }
+
                     break;
                 }
 
@@ -357,7 +366,7 @@ namespace Impostor.Server.Net.State
                     }
 
                     // Hook up InnerPlayerControl <-> InnerPlayerControl.PlayerInfo.
-                    var playerInfo = GameNet.GameData!.GetPlayerById(control.PlayerId) ?? GameNet.GameData.AddPlayer(control);
+                    var playerInfo = GameNet.GameData.GetPlayerById(control.PlayerId);
 
                     if (playerInfo != null)
                     {
@@ -401,12 +410,6 @@ namespace Impostor.Server.Net.State
                     break;
                 }
 
-                case InnerGameData:
-                {
-                    GameNet.GameData = null;
-                    break;
-                }
-
                 case InnerVoteBanSystem:
                 {
                     GameNet.VoteBan = null;
@@ -419,13 +422,18 @@ namespace Impostor.Server.Net.State
                     break;
                 }
 
-                case InnerPlayerControl control:
+                case InnerPlayerInfo playerInfo:
                 {
                     if (GameState != GameStates.Started && GameState != GameStates.Starting)
                     {
-                        GameNet.GameData?.RemovePlayer(control);
+                        GameNet.GameData.RemovePlayer(playerInfo.PlayerId);
                     }
 
+                    break;
+                }
+
+                case InnerPlayerControl control:
+                {
                     // Remove InnerPlayerControl <-> IClientPlayer.
                     if (TryGetPlayer(control.OwnerId, out var player))
                     {

--- a/src/Impostor.Server/Net/State/GameNet.Api.cs
+++ b/src/Impostor.Server/Net/State/GameNet.Api.cs
@@ -12,7 +12,7 @@ namespace Impostor.Server.Net.State
 
         IInnerLobbyBehaviour? IGameNet.LobbyBehaviour => LobbyBehaviour;
 
-        IInnerGameData? IGameNet.GameData => GameData;
+        IInnerGameData IGameNet.GameData => GameData;
 
         IInnerVoteBanSystem? IGameNet.VoteBan => VoteBan;
 

--- a/src/Impostor.Server/Net/State/GameNet.cs
+++ b/src/Impostor.Server/Net/State/GameNet.cs
@@ -11,7 +11,7 @@ namespace Impostor.Server.Net.State
 
         public InnerLobbyBehaviour? LobbyBehaviour { get; internal set; }
 
-        public InnerGameData? GameData { get; internal set; }
+        public InnerGameData GameData { get; internal set; } = new();
 
         public InnerVoteBanSystem? VoteBan { get; internal set; }
 


### PR DESCRIPTION
In 2024.6.18 Innersloth promoted PlayerInfo to its own network object, and gave it to the server. InnerGameData is now a container that holds these players. This commit implements the changes necessary to handle these separate PlayerInfo network objects.
