### PR TITLE
Reset PlayerInfo on PlayerControl spawn

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -402,6 +402,13 @@ namespace Impostor.Server.Net.State
                     {
                         playerInfo.Controller = control;
                         control.PlayerInfo = playerInfo;
+
+                        // Reset PlayerInfo
+                        playerInfo.RoleType = null;
+                        playerInfo.RoleWhenAlive = null;
+                        playerInfo.Tasks.Clear();
+                        playerInfo.IsDead = false;
+                        playerInfo.IsDirty = true;
                     }
 
                     if (player != null)


### PR DESCRIPTION
When (re)spawning players get a new player control netobject, which is
the perfect moment to discharge them from their former duties and reset
their PlayerInfo to a default state: no role, no tasks and not dead.