### PR TITLE
Let hosts handle exiles

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
@@ -289,7 +289,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
             if (exiled != null)
             {
-                exiled.Die(DeathReason.Exile);
+                exiled.PlayerInfo.LastDeathReason = DeathReason.Exile;
                 await _eventManager.CallAsync(new PlayerExileEvent(Game, Game.GetClientPlayer(exiled!.OwnerId)!, exiled));
             }
 


### PR DESCRIPTION
### Description

Previously Impostor liked to kill exiled players server side to raise an event. This is quite early, as the host will SetRole them to a ghost role later.

However as PlayerInfo is server-owned by default in 2024.6.18, it starts killing players client side. This caused meetings to immediately conclude if the final impostor was voted out, ruining the cutscene.

So this commit makes Impostor wait for hosts to actually kill the player using SetRole.
