### PR TITLE
Add NetId to SetName and SetColor

### DIFF
--- a/src/Impostor.Api/Net/Messages/Rpcs/Rpc06SetName.cs
+++ b/src/Impostor.Api/Net/Messages/Rpcs/Rpc06SetName.cs
@@ -2,13 +2,15 @@ namespace Impostor.Api.Net.Messages.Rpcs
 {
     public static class Rpc06SetName
     {
-        public static void Serialize(IMessageWriter writer, string name)
+        public static void Serialize(IMessageWriter writer, uint netId, string name)
         {
+            writer.Write(netId);
             writer.Write(name);
         }
 
-        public static void Deserialize(IMessageReader reader, out string name)
+        public static void Deserialize(IMessageReader reader, out uint netId, out string name)
         {
+            netId = reader.ReadUInt32();
             name = reader.ReadString();
         }
     }

--- a/src/Impostor.Api/Net/Messages/Rpcs/Rpc08SetColor.cs
+++ b/src/Impostor.Api/Net/Messages/Rpcs/Rpc08SetColor.cs
@@ -4,13 +4,15 @@ namespace Impostor.Api.Net.Messages.Rpcs
 {
     public static class Rpc08SetColor
     {
-        public static void Serialize(IMessageWriter writer, ColorType color)
+        public static void Serialize(IMessageWriter writer, uint netId, ColorType color)
         {
+            writer.Write(netId);
             writer.Write((byte)color);
         }
 
-        public static void Deserialize(IMessageReader reader, out ColorType color)
+        public static void Deserialize(IMessageReader reader, out uint netId, out ColorType color)
         {
+            netId = reader.ReadUInt32();
             color = (ColorType)reader.ReadByte();
         }
     }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -32,7 +32,7 @@ namespace Impostor.Server.Net.Inner.Objects
             PlayerInfo.CurrentOutfit.Color = color;
 
             using var writer = Game.StartRpc(NetId, RpcCalls.SetColor);
-            Rpc08SetColor.Serialize(writer, color);
+            Rpc08SetColor.Serialize(writer, PlayerInfo.NetId, color);
             await Game.FinishRpcAsync(writer);
         }
 

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -167,7 +167,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
-                    Rpc06SetName.Deserialize(reader, out var name);
+                    Rpc06SetName.Deserialize(reader, out var _, out var name);
                     return await HandleSetName(sender, name);
                 }
 
@@ -191,7 +191,7 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
-                    Rpc08SetColor.Deserialize(reader, out var color);
+                    Rpc08SetColor.Deserialize(reader, out var _, out var color);
                     return await HandleSetColor(sender, color);
                 }
 


### PR DESCRIPTION
### Description

2024.6.18 adds a NetId field *in front* of the existing fields to help link back to the PlayerInfo. We don't actually need this NetId and assume it's called on the correct PlayerControl, so we ignore it.