### PR TITLE
Add compatibility option to allow host authority

### DIFF
--- a/docs/Server-configuration.md
+++ b/docs/Server-configuration.md
@@ -43,12 +43,13 @@ Impostor has an Anticheat that makes it possible to kick cheaters from games aut
 
 ### Compatibility
 
-Impostor has two compatibility options which allow some extra flexibility but may not work properly. Enabling either of these options is not recommended.
+Impostor has some compatibility options which allow some extra flexibility but may not work properly. Enabling any of these options is not recommended. When contacting support, please mention which of these options are enabled.
 
-| Key                      | Default | Value                                                                                                                                                                          |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **AllowNewGameVersions** | `false` | Warning: Setting this option to `true` is unsupported and may cause issues when large updates to Among Us are released. Allow future versions of Among Us to join your server. |
-| **AllowVersionMixing**   | `false` | Allow players using different game versions to play in one lobby.                                                                                                              |
+| Key                         | Default | Value                                                                                                                                                                                                                                                            |
+|-----------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **AllowFutureGameVersions** | `false` | Warning: Setting this option to `true` is unsupported and may cause issues when large updates to Among Us are released, but can be useful when a small patch is released. Allows future versions of Among Us to join your server.                                |
+| **AllowHostAuthority**      | `false` | Certain Among Us mods allow disabling some server-authoritative features, which also changes some code paths in the client. These code paths have not undergone as much testing and contain bugs, which can't be fixed from the Impostor side. Use with caution. |
+| **AllowVersionMixing**      | `false` | Allows players using different game versions to play in one lobby that have not been marked by the Impostor developers as compatible.                                                                                                                            |
 
 ### Debug
 

--- a/src/Impostor.Api/Config/CompatibilityConfig.cs
+++ b/src/Impostor.Api/Config/CompatibilityConfig.cs
@@ -6,6 +6,8 @@ namespace Impostor.Api.Config
 
         public bool AllowFutureGameVersions { get; set; } = false;
 
+        public bool AllowHostAuthority { get; set; } = false;
+
         public bool AllowVersionMixing { get; set; } = false;
     }
 }

--- a/src/Impostor.Api/Config/DisconnectMessages.cs
+++ b/src/Impostor.Api/Config/DisconnectMessages.cs
@@ -30,5 +30,7 @@
                                                         Sorry, UDP Matchmaking is no longer supported.
                                                         See <link={UpgradingDocsLink}#impostor-190>Impostor documentation</link> on how to migrate to HTTP Matchmaking
                                                         """;
+
+        public const string HostAuthorityUnsupported = "Your client is requesting host authority, which is not enabled on this Impostor server.";
     }
 }

--- a/src/Impostor.Server/full-config-example.json
+++ b/src/Impostor.Server/full-config-example.json
@@ -29,6 +29,7 @@
   },
   "Compatibility": {
     "AllowFutureGameVersions": false,
+    "AllowHostAuthority": false,
     "AllowVersionMixing": false
   },
   "Debug": {


### PR DESCRIPTION
### Description

There are various bugs in the 2024.6.18 implementation of host-authoritive multiplayer such that I can't recommend players to use it. Fixing these issues on the server side is impossible, and I can't smell remotely if clients have applied the necessary fixes. The currently known bugs include at least:

- Unable to join more than 8 players in a room
- Unable for new players to join if host switched from host authoritive to server authoritive
- Host is unable to kill if it is in a host authoritive game while it thinks it is in server authoritive mode

If Innersloth fixes this mode in future game patches, this option may be reconsidered.
