### PR TITLE
Add Message24EndGameHostMigration serialization

### DIFF
--- a/src/Impostor.Api/Net/Messages/MessageFlags.cs
+++ b/src/Impostor.Api/Net/Messages/MessageFlags.cs
@@ -28,6 +28,7 @@ namespace Impostor.Api.Net.Messages
         public const byte SetActivePodType = 21;
         public const byte QueryPlatformIds = 22;
         public const byte QueryLobbyInfo = 23;
+        public const byte EndGameHostMigration = 24;
 
         private static readonly Dictionary<byte, string> FlagCache;
 

--- a/src/Impostor.Api/Net/Messages/S2C/Message24EndGameHostMigrationS2C.cs
+++ b/src/Impostor.Api/Net/Messages/S2C/Message24EndGameHostMigrationS2C.cs
@@ -1,0 +1,21 @@
+using Impostor.Api.Games;
+
+namespace Impostor.Api.Net.Messages.S2C
+{
+    public class Message24EndGameHostMigrationS2C
+    {
+        public static void Serialize(IMessageWriter writer, GameCode gameCode, int hostClientId)
+        {
+            writer.StartMessage(MessageFlags.EndGameHostMigration);
+            gameCode.Serialize(writer);
+            writer.Write(hostClientId);
+            writer.EndMessage();
+        }
+
+        public static void Deserialize(IMessageReader reader, out GameCode gameCode, out int hostClientId)
+        {
+            gameCode = reader.ReadInt32();
+            hostClientId = reader.ReadInt32();
+        }
+    }
+}


### PR DESCRIPTION
### Description

Looks like Innersloth added this but hasn't actually used this. Weird..

When sent it makes the new host perform a full rejoin, which gums up Impostor's spawning logic. Fixing that causes the client to gum itself up. Sigh.

After some testing it seems like host migration still works fine, so this investigation wasn't needed. Committing for posterity.

