### PR TITLE
Don't DC the client if they send an unknown flag

### DIFF
--- a/src/Impostor.Api/Net/Messages/MessageFlags.cs
+++ b/src/Impostor.Api/Net/Messages/MessageFlags.cs
@@ -41,7 +41,7 @@ namespace Impostor.Api.Net.Messages
 
         public static string FlagToString(byte flag)
         {
-            return FlagCache[flag];
+            return FlagCache.TryGetValue(flag, out var res) ? res : $"Unknown Flag {flag}";
         }
     }
 }


### PR DESCRIPTION
### Description

This item is only used in a LogTrace call, so it seems excessive to kick a player on servers just for a log statement
