### PR TITLE
Bump System.Text.Json to 8.0.4

### DIFF
--- a/src/Impostor.Api.Innersloth.Generator/Impostor.Api.Innersloth.Generator.csproj
+++ b/src/Impostor.Api.Innersloth.Generator/Impostor.Api.Innersloth.Generator.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
 
-    <PackageReference Include="System.Text.Json" Version="8.0.0" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" PrivateAssets="all" GeneratePathProperty="true" />
 

--- a/src/Impostor.Api.Innersloth.Generator/packages.lock.json
+++ b/src/Impostor.Api.Innersloth.Generator/packages.lock.json
@@ -60,9 +60,9 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "requested": "[8.0.4, )",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
           "System.Buffers": "4.5.1",


### PR DESCRIPTION
### Description

Fixes CVE-2024-30105 (High 7.5/10)
https://github.com/advisories/GHSA-hh2w-p6rv-4g7w

Impostor doesn't use the affected
JsonSerializer.DeserializeAsyncEnumerable method as it doesn't accept JSON formatted payloads, but the NU1903 warning is shown on all builds, leading to warning fatigue.
