### PR TITLE
Set PlayerLevel in PlayerInfo on RPC SetLevel

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -251,7 +251,7 @@ namespace Impostor.Server.Net.Inner.Objects
                     }
 
                     Rpc38SetLevel.Deserialize(reader, out var level);
-                    return true;
+                    return await HandleSetLevel(sender, level);
                 }
 
                 case RpcCalls.ReportDeadBody:
@@ -830,6 +830,19 @@ namespace Impostor.Server.Net.Inner.Objects
             }
 
             PlayerInfo.CurrentOutfit.NamePlateId = skin;
+
+            return true;
+        }
+
+        private async ValueTask<bool> HandleSetLevel(ClientPlayer sender, uint level)
+        {
+            if (Game.GameState == GameStates.Started &&
+                await sender.Client.ReportCheatAsync(RpcCalls.SetLevel, CheatCategory.GameFlow, "Client tried to set level while not in game"))
+            {
+                return false;
+            }
+
+            PlayerInfo.PlayerLevel = level;
 
             return true;
         }


### PR DESCRIPTION
Previously this used to be done by the host, but this is now the server's responsibility.

I'm unable to test this, but I'm pretty certain this would work on paper. Marking as draft until someone verifies this.

Test Plan:
- Probably merge this patch on the octopus branch to get a working Impostor
- Do not use any mods, most notably do not use any mod that enables host-authoritive networking.
- Get an Among Us account with at least level 2
- Join a game with at least 4 players
- Start a meeting
- Observe that with this patch, the player level is set correctly and without this patch it is not.

For people that attempt to be smart and UnityExplorer their way out of this: Among Us offsets levels by 1, so player level 0 will show as level 1.
