### PR TITLE
Add Rpc44SetRole To Changing NetworkedPlayerInfo.IsDead

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -390,6 +390,10 @@ namespace Impostor.Server.Net.Inner.Objects
                         PlayerInfo.RoleWhenAlive = PlayerInfo.RoleType;
                         PlayerInfo.IsDead = true;
                     }
+                    else
+                    {
+                        PlayerInfo.IsDead = false;
+                    }
 
                     PlayerInfo.RoleType = role;
                     PlayerInfo.IsDirty = true;


### PR DESCRIPTION
### Description

Some mod requires flexible change of player state.
Currently, there is no way to reset NetworkedPlayerInfo.IsDead to False.
This PR adds means of reviving to Impostor.