### PR TITLE
Switch PlayerName writes to Outfit

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.Api.cs
@@ -20,7 +20,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public async ValueTask SetNameAsync(string name)
         {
-            PlayerInfo.PlayerName = name;
+            PlayerInfo.CurrentOutfit.PlayerName = name;
 
             using var writer = Game.StartRpc(NetId, RpcCalls.SetName);
             writer.Write(name);

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerControl.cs
@@ -686,7 +686,7 @@ namespace Impostor.Server.Net.Inner.Objects
                 }
             }
 
-            PlayerInfo.PlayerName = name;
+            PlayerInfo.CurrentOutfit.PlayerName = name;
 
             return true;
         }

--- a/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerPlayerInfo.cs
@@ -29,7 +29,7 @@ namespace Impostor.Server.Net.Inner.Objects
 
         public int ClientId { get; internal set; }
 
-        public string PlayerName { get; internal set; } = string.Empty;
+        public string PlayerName => CurrentOutfit.PlayerName;
 
         public Dictionary<PlayerOutfitType, PlayerOutfit> Outfits { get; } = new()
         {


### PR DESCRIPTION
### Description

In 2024.6.18 Innersloth changed the storage location of the PlayerName from PlayerInfo to PlayerOutfit. If we don't set the PlayerName, we'll send an incomplete PlayerInfo to new players, so new players are unable to stay connected as they will not receive complete PlayerInfo objects before a timeout in the client activates.

Because we publish PlayerName in the API, we can't completely remove the PlayerName field from PlayerInfo. We also use it internally in a few places, so I don't this is worth removing.

These changes were ported out of #616, which is rejected.