### PR TITLE
Implementing SerializeAsync and DeserializeAsync for InnerPlayerPhysics

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/Components/InnerPlayerPhysics.cs
@@ -27,12 +27,12 @@ namespace Impostor.Server.Net.Inner.Objects.Components
 
         public override ValueTask<bool> SerializeAsync(IMessageWriter writer, bool initialState)
         {
-            throw new NotImplementedException();
+            return new ValueTask<bool>(false);
         }
 
         public override ValueTask DeserializeAsync(IClientPlayer sender, IClientPlayer? target, IMessageReader reader, bool initialState)
         {
-            throw new NotImplementedException();
+            return ValueTask.CompletedTask;
         }
 
         public override async ValueTask<bool> HandleRpcAsync(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)


### PR DESCRIPTION
### Description

Its implementation itself is a no-op and should not throw an unimplemented error
