### PR TITLE
Support LobbyBehaviour Rpc calls

### DIFF
--- a/src/Impostor.Api/Net/Messages/Rpcs/Rpc60LobbyTimeExpiring.cs
+++ b/src/Impostor.Api/Net/Messages/Rpcs/Rpc60LobbyTimeExpiring.cs
@@ -1,0 +1,39 @@
+namespace Impostor.Api.Net.Messages.Rpcs
+{
+    public static class Rpc60LobbyTimeExpiring
+    {
+        public static void Serialize(IMessageWriter writer, int timeRemainingSeconds, bool isExtensionAvailable, int hostId = 255, int extensionId = 0, int extendedTimeSeconds = 0)
+        {
+            writer.WritePacked(timeRemainingSeconds);
+            writer.Write(isExtensionAvailable);
+            if (isExtensionAvailable)
+            {
+                // The following parameters is not used in vanilla code.
+                writer.WritePacked(hostId);
+                writer.WritePacked(extensionId);
+                writer.WritePacked(extendedTimeSeconds);
+            }
+        }
+
+        public static void Deserialize(IMessageReader reader, out int timeRemainingSeconds, out bool isExtensionAvailable, out int hostId, out int extensionId, out int extendedTimeSeconds)
+        {
+            timeRemainingSeconds = reader.ReadPackedInt32();
+            isExtensionAvailable = reader.ReadBoolean();
+
+            if (isExtensionAvailable)
+            {
+                hostId = reader.ReadPackedInt32();
+                extensionId = reader.ReadPackedInt32();
+                extendedTimeSeconds = reader.ReadPackedInt32();
+
+                // extensionId is not used in vanilla code and there is no enum matching this "extension Id" in code.
+            }
+            else
+            {
+                hostId = 255;
+                extensionId = 0;
+                extendedTimeSeconds = 0;
+            }
+        }
+    }
+}

--- a/src/Impostor.Api/Net/Messages/Rpcs/Rpc61ExtendLobbyTimer.cs
+++ b/src/Impostor.Api/Net/Messages/Rpcs/Rpc61ExtendLobbyTimer.cs
@@ -1,0 +1,33 @@
+namespace Impostor.Api.Net.Messages.Rpcs
+{
+    public static class Rpc61ExtendLobbyTimer
+    {
+        public static void Serialize(IMessageWriter writer, int extensionId, bool isSuccess, byte extensionFailureReasons)
+        {
+            writer.WritePacked(extensionId);
+            writer.Write(isSuccess);
+            if (!isSuccess)
+            {
+                writer.Write(extensionFailureReasons);
+            }
+        }
+
+        public static void Deserialize(IMessageReader reader, out int extensionId, out bool isSuccess, out byte extensionFailureReasons)
+        {
+            extensionId = reader.ReadPackedInt32();
+            isSuccess = reader.ReadBoolean();
+
+            if (!isSuccess)
+            {
+                extensionFailureReasons = reader.ReadByte();
+
+                // The game currently only logs the failure reason and dont act on it.
+                // ExtensionFailureReasons enum exists in code but is not used, not adding it here until InnerSloth put real use to it.
+            }
+            else
+            {
+                extensionFailureReasons = 0;
+            }
+        }
+    }
+}

--- a/src/Impostor.Server/Net/Inner/Objects/InnerLobbyBehaviour.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerLobbyBehaviour.cs
@@ -1,27 +1,81 @@
-﻿using System;
 using System.Threading.Tasks;
+using Impostor.Api;
 using Impostor.Api.Net;
 using Impostor.Api.Net.Custom;
+using Impostor.Api.Net.Inner;
 using Impostor.Api.Net.Inner.Objects;
+using Impostor.Api.Net.Messages.Rpcs;
 using Impostor.Server.Net.State;
+using Microsoft.Extensions.Logging;
 
 namespace Impostor.Server.Net.Inner.Objects
 {
     internal class InnerLobbyBehaviour : InnerNetObject, IInnerLobbyBehaviour
     {
-        public InnerLobbyBehaviour(ICustomMessageManager<ICustomRpc> customMessageManager, Game game) : base(customMessageManager, game)
+        private readonly ILogger<InnerLobbyBehaviour> _logger;
+
+        public InnerLobbyBehaviour(ICustomMessageManager<ICustomRpc> customMessageManager, Game game, ILogger<InnerLobbyBehaviour> logger) : base(customMessageManager, game)
         {
+            _logger = logger;
             Components.Add(this);
         }
 
         public override ValueTask<bool> SerializeAsync(IMessageWriter writer, bool initialState)
         {
-            throw new NotImplementedException();
+            return new ValueTask<bool>(false);
         }
 
         public override ValueTask DeserializeAsync(IClientPlayer sender, IClientPlayer? target, IMessageReader reader, bool initialState)
         {
-            throw new NotImplementedException();
+            return default;
+        }
+
+        public override async ValueTask<bool> HandleRpcAsync(ClientPlayer sender, ClientPlayer? target, RpcCalls call, IMessageReader reader)
+        {
+            switch (call)
+            {
+                case RpcCalls.LobbyTimeExpiring:
+                {
+                    if (await sender.Client.ReportCheatAsync(RpcCalls.LobbyTimeExpiring, CheatCategory.ProtocolExtension, "Client should never send LobbyTimeExpiring."))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateHost(call, sender))
+                    {
+                        return false;
+
+                        // Some Host-Only mods is using this Rpc to sync room close time on vanilla server.
+                        // It should be a good practice to only allow host to send this rpc if Protocol Extension is enabled.
+                    }
+
+                    Rpc60LobbyTimeExpiring.Deserialize(reader, out var timeRemainingSeconds, out _, out _, out _, out _);
+                    _logger.LogInformation("{0} - {1} sent Lobby time expiring for {2}s", sender.Game.Code, sender.Client.Id, timeRemainingSeconds);
+                    break;
+                }
+
+                case RpcCalls.ExtendLobbyTimer:
+                {
+                    if (await sender.Client.ReportCheatAsync(RpcCalls.ExtendLobbyTimer, CheatCategory.ProtocolExtension, "Client should never send ExtendLobbyTimer."))
+                    {
+                        return false;
+                    }
+
+                    if (!await ValidateHost(call, sender))
+                    {
+                        return false;
+                    }
+
+                    Rpc61ExtendLobbyTimer.Deserialize(reader, out _, out _, out _);
+                    _logger.LogInformation("{0} - {1} sent Extend Lobby Timer", sender.Game.Code, sender.Client.Id);
+                    break;
+                }
+
+                default:
+                    return await base.HandleRpcAsync(sender, target, call, reader);
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
LobbyTimeExpiring is used in vanilla servers to broadcast room closing messages. Maybe some plugins can use it to close rooms.
ExtendLobbyTimer seems never used but it exists in code to cancel LobbyTimeExpiring.

Also LobbyTimeExpiring rpcs can produce awesome noises. Suggest adding it as anticheat purpose