### PR TITLE
Fix null reference when +25 host despawn playerinfo before server could

### DIFF
--- a/src/Impostor.Server/Net/State/Game.State.cs
+++ b/src/Impostor.Server/Net/State/Game.State.cs
@@ -88,8 +88,10 @@ namespace Impostor.Server.Net.State
             // Clean up the PlayerInfo if we own it and we're still in the lobby
             if (GameState == GameStates.NotStarted)
             {
-                var playerInfo = GameNet.GameData.PlayersByClientId[playerId];
-                await DespawnPlayerInfoAsync(playerInfo);
+                if (GameNet.GameData.PlayersByClientId.TryGetValue(playerId, out var playerInfo))
+                {
+                    await DespawnPlayerInfoAsync(playerInfo);
+                }
             }
 
             return true;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fff1e817-a658-4976-b7fb-a7571a9c2772)
+25 protocol, sometimes player disconnects and host sent despawn playerinfo before server could remove it from dictionary