### PR TITLE
Fix cheating disconnect message

### DIFF
--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -86,9 +86,14 @@ namespace Impostor.Server.Net
 
             _logger.LogWarning("Client {Name} ({Id}) was caught cheating: [{SupportCode}] [{Context}-{Category}] {Message}", Name, Id, supportCode, context.Name, category, message);
 
-            if (_antiCheatConfig.BanIpFromGame)
+            if (Player is { } player)
             {
-                Player?.Game.BanIp(Connection.EndPoint.Address);
+                if (_antiCheatConfig.BanIpFromGame)
+                {
+                    player.Game.BanIp(Connection.EndPoint.Address);
+                }
+
+                await player.Game.HandleRemovePlayer(Id, DisconnectReason.Hacking);
             }
 
             var disconnectMessage =

--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -82,14 +82,22 @@ namespace Impostor.Server.Net
                 return false;
             }
 
-            _logger.LogWarning("Client {Name} ({Id}) was caught cheating: [{Context}-{Category}] {Message}", Name, Id, context.Name, category, message);
+            var supportCode = Random.Shared.Next(0, 999_999).ToString("000-000");
+
+            _logger.LogWarning("Client {Name} ({Id}) was caught cheating: [{SupportCode}] [{Context}-{Category}] {Message}", Name, Id, supportCode, context.Name, category, message);
 
             if (_antiCheatConfig.BanIpFromGame)
             {
                 Player?.Game.BanIp(Connection.EndPoint.Address);
             }
 
-            await DisconnectAsync(DisconnectReason.Hacking, context.Name + ": " + message);
+            var disconnectMessage =
+                $"""
+                 You have been caught cheating and were {(_antiCheatConfig.BanIpFromGame ? "banned" : "kicked")} from the lobby.
+                 For questions, contact your server admin and share the following code: {supportCode}.
+                 """;
+
+            await DisconnectAsync(DisconnectReason.Custom, disconnectMessage);
 
             return true;
         }


### PR DESCRIPTION
DisconnectReason.Hacking has been broken in base game for a long time so replace it with a custom message. Also add a random support code for easier debugging in case of false positives.

Current:
![image](https://github.com/user-attachments/assets/fc9d911d-d941-4504-a67c-059c48a9494a)

This PR:
![image](https://github.com/user-attachments/assets/1c15baac-e1d3-4231-a41a-8acf91b7c326)