### PR TITLE
Fix RemovePlayer reason on internal disconnects

### DIFF
--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -348,7 +348,9 @@ namespace Impostor.Server.Net
             {
                 if (Player != null)
                 {
-                    await Player.Game.HandleRemovePlayer(Id, DisconnectReason.ExitGame);
+                    // The client never sends over the real disconnect reason so we always assume ExitGame
+                    var isRemote = reason == "The remote sent a disconnect request";
+                    await Player.Game.HandleRemovePlayer(Id, isRemote ? DisconnectReason.ExitGame : DisconnectReason.Error);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Previously all disconnections were broadcasted as `DisconnectReason.ExitGame` regardless of whether the disconnect was initiated by us or the client. This PR makes it so our disconnects use `DisconnectReason.Error` instead.

If in the future base game supports more `DisconnectReason`s in the notification message we could use more specific reasons using `HazelInternalErrors` provided by `NetworkConnection.OnInternalDisconnect`.

pressing "Leave Game":
![image](https://github.com/user-attachments/assets/298b39aa-814d-4f2b-a0bf-91f88e34334a)

network timeout:
![image](https://github.com/user-attachments/assets/bb3e7cae-b551-4529-803c-71eb92a94883)

cc @NikoCat233 