### PR TITLE
Prevent vanilla host from spawning or serializing NetworkedPlayerInfo

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -348,6 +348,11 @@ namespace Impostor.Server.Net.State
 
                 case InnerPlayerInfo playerInfo:
                 {
+                    if (!IsHostAuthoritive && await sender.Client.ReportCheatAsync(new CheatContext(nameof(GameDataTag.SpawnFlag)), CheatCategory.ProtocolExtension, "Spawning NetworkedPlayerInfo as vanilla host"))
+                    {
+                        return;
+                    }
+
                     if (!GameNet.GameData.AddPlayer(playerInfo))
                     {
                         _logger.LogWarning(


### PR DESCRIPTION
We should also do

Prevent Serialize packets from being sent to clients.
 (currently we only kick the sender, objects may still be serialized. Some serialize packets should be canceled anyway even when we decide not to kick the sender)

Destory illegally spawned objects.
(Current checks first create the instance, then check the spawned instance after spawn is finished. Spawn anticheat should be added before actually creating the instance and should be canceled when following initial data serialize check failed)

Networked Playerinfo related serializing and spawning should be in a proper CheatCategory rather than ProtocolExtensions, which is commonly disabled on most servers

