### PR TITLE
Let server serialize certain root messages instead of copying from host

### DIFF
--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -198,7 +198,7 @@ namespace Impostor.Server.Net
                         return;
                     }
 
-                    await Player!.Game.HandleStartGame(reader);
+                    await Player!.Game.HandleStartGame();
                     break;
                 }
 
@@ -269,7 +269,7 @@ namespace Impostor.Server.Net
                         reader,
                         out var gameOverReason);
 
-                    await Player!.Game.HandleEndGame(reader, gameOverReason);
+                    await Player!.Game.HandleEndGame(gameOverReason);
                     break;
                 }
 
@@ -290,7 +290,7 @@ namespace Impostor.Server.Net
                         return;
                     }
 
-                    await Player!.Game.HandleAlterGame(reader, Player, value);
+                    await Player!.Game.HandleAlterGame(Player, gameTag, value);
                     break;
                 }
 


### PR DESCRIPTION
Root messages like StartGame, EndGame and AlterGame should be serialized by server instead of copying from host's packets.
I believe no mods will write their stuffs in these root message,
 and server serializing these root messages is better for anticheat purpose.