### PR TITLE
Add 207 XboxDeclareXuid | Correctly handle unknown gamedata tag

### DIFF
--- a/src/Impostor.Server/Net/Inner/GameDataTag.cs
+++ b/src/Impostor.Server/Net/Inner/GameDataTag.cs
@@ -1,4 +1,4 @@
-﻿namespace Impostor.Server.Net.Inner
+namespace Impostor.Server.Net.Inner
 {
     public static class GameDataTag
     {
@@ -11,5 +11,6 @@
         public const byte ChangeSettingsFlag = 8;
         public const byte ConsoleDeclareClientPlatformFlag = 205;
         public const byte PS4RoomRequest = 206;
+        public const byte XboxDeclareXuid = 207;
     }
 }

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -315,7 +315,18 @@ namespace Impostor.Server.Net.State
 
                     default:
                     {
-                        _logger.LogWarning("Bad GameData tag {0}", reader.Tag);
+                        if (Enum.IsDefined(typeof(GameDataTag), reader.Tag))
+                        {
+                            _logger.LogDebug("Get vanilla GameData tag {0} that isn't handled.", reader.Tag);
+                            break;
+                        }
+
+                        if (await sender.Client.ReportCheatAsync(new CheatContext("GameDataTag.Unknown"), CheatCategory.ProtocolExtension, $"Client sent unknown GameData tag {reader.Tag}"))
+                        {
+                            return false;
+                        }
+
+                        _logger.LogWarning("Get Unknown GameData tag {0}", reader.Tag);
                         break;
                     }
                 }


### PR DESCRIPTION
Added 207 XboxDeclareXuid, which previously cause a warning log

Upon receiving unhandled gamedata tag, we first check whether it is defined in vanilla protocol.
If not, we check protocol extension anticheat, reject the packet if anticheat flags, or log warning and continue broadcasting.

Change warning message to Debug and cheat detection to avoid unnecessary logging