### PR TITLE
Fix abandoned game creation

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
-    <VersionPrefix>1.10.1</VersionPrefix>
+    <VersionPrefix>1.10.2</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
     <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Impostor.Api/Net/IClient.cs
+++ b/src/Impostor.Api/Net/IClient.cs
@@ -8,7 +8,7 @@ namespace Impostor.Api.Net
     /// <summary>
     ///     Represents a connected game client.
     /// </summary>
-    public interface IClient
+    public interface IClient : IEquatable<IClient>
     {
         /// <summary>
         ///     Gets or sets the unique ID of the client.

--- a/src/Impostor.Server/Net/Client.cs
+++ b/src/Impostor.Server/Net/Client.cs
@@ -373,6 +373,7 @@ namespace Impostor.Server.Net
 
             _logger.LogInformation("Client {0} disconnecting, reason: {1}", Id, reason);
             _clientManager.Remove(this);
+            await _gameManager.OnClientDisconnectAsync(this);
         }
 
         private bool IsPacketAllowed(IMessageReader message, bool hostOnly)

--- a/src/Impostor.Server/Net/ClientBase.cs
+++ b/src/Impostor.Server/Net/ClientBase.cs
@@ -59,5 +59,20 @@ namespace Impostor.Server.Net
         {
             await Connection.CustomDisconnectAsync(reason, message);
         }
+
+        public bool Equals(IClient? other)
+        {
+            return other != null && Id == other.Id;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return Equals(obj as ClientBase);
+        }
+
+        public override int GetHashCode()
+        {
+            return Id;
+        }
     }
 }

--- a/src/Impostor.Server/Net/Hazel/HazelConnection.cs
+++ b/src/Impostor.Server/Net/Hazel/HazelConnection.cs
@@ -69,6 +69,11 @@ namespace Impostor.Server.Net.Hazel
                 {
                     await Client.HandleMessageAsync(message, e.Type);
                 }
+
+                if (!IsConnected)
+                {
+                    break;
+                }
             }
         }
     }

--- a/src/Impostor.Server/Net/Manager/GameManager.cs
+++ b/src/Impostor.Server/Net/Manager/GameManager.cs
@@ -31,6 +31,7 @@ namespace Impostor.Server.Net.Manager
         private readonly IEventManager _eventManager;
         private readonly IGameCodeFactory _gameCodeFactory;
         private readonly ICompatibilityManager _compatibilityManager;
+        private readonly ConcurrentDictionary<IClient, Game?> _gamesCreatedBy;
 
         public GameManager(
             ILogger<GameManager> logger,
@@ -49,6 +50,7 @@ namespace Impostor.Server.Net.Manager
             _games = new ConcurrentDictionary<int, Game>();
             _compatibilityConfig = compatibilityConfig.Value;
             _compatibilityManager = compatibilityManager;
+            _gamesCreatedBy = new ConcurrentDictionary<IClient, Game?>();
         }
 
         IEnumerable<IGame> IGameManager.Games => _games.Select(kv => kv.Value);
@@ -85,6 +87,12 @@ namespace Impostor.Server.Net.Manager
 
         public async ValueTask<IGame?> CreateAsync(IClient? owner, IGameOptions options, GameFilterOptions filterOptions)
         {
+            if (owner != null && !_gamesCreatedBy.TryAdd(owner, null))
+            {
+                _logger.LogWarning("Connection {Name}({ClientId}) has tried to create a second game, blocked", owner.Name, owner.Id);
+                return null;
+            }
+
             var @event = new GameCreationEvent(this, owner);
             await _eventManager.CallAsync(@event);
 
@@ -98,6 +106,11 @@ namespace Impostor.Server.Net.Manager
             for (var i = 0; i < 10 && !success; i++)
             {
                 (success, game) = await TryCreateAsync(options, filterOptions, owner);
+            }
+
+            if (owner != null)
+            {
+                _gamesCreatedBy[owner] = game;
             }
 
             if (!success || game == null)

--- a/src/Impostor.Server/Net/Manager/GameManager.cs
+++ b/src/Impostor.Server/Net/Manager/GameManager.cs
@@ -142,5 +142,14 @@ namespace Impostor.Server.Net.Manager
 
             return (true, game);
         }
+
+        internal async ValueTask OnClientDisconnectAsync(IClient client)
+        {
+            if (_gamesCreatedBy.TryRemove(client, out var game) && game is { PlayerCount: 0, GameState: not GameStates.Destroyed })
+            {
+                _logger.LogWarning("Client {Name}({ClientId}) left empty game open when disconnecting", client.Name, client.Id);
+                await RemoveAsync(game.Code);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description

This PR fixes an issue where malicious clients could create games but not join them, leaving empty games lingering on Impostor servers.

Battle tested for 3 days on the Modded servers, no regressions reported.