### PR TITLE
Add Murder/Protect/Exile API without checks

### DIFF
--- a/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
+++ b/src/Impostor.Api/Net/Inner/Objects/IInnerPlayerControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Impostor.Api.Innersloth;
 using Impostor.Api.Innersloth.Customization;
@@ -102,28 +103,52 @@ namespace Impostor.Api.Net.Inner.Objects
         ValueTask MurderPlayerAsync(IInnerPlayerControl target, MurderResultFlags result);
 
         /// <summary>
-        ///     Murder <paramref name="target" /> player successfully.
+        /// Murder <paramref name="target" /> player.
+        /// </summary>
+        /// <param name="target">Target player to murder.</param>
+        /// <param name="result">The result of the murder operation.</param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask ForceMurderPlayerAsync(IInnerPlayerControl target, MurderResultFlags result);
+
+        /// <summary>
+        ///     Murder <paramref name="target" /> player after validating if this is a valid kill.
         /// </summary>
         /// <param name="target">Target player to murder.</param>
         /// <exception cref="ImpostorProtocolException">Thrown when player is not the impostor.</exception>
         /// <exception cref="ImpostorProtocolException">Thrown when player is dead.</exception>
         /// <exception cref="ImpostorProtocolException">Thrown when target is dead.</exception>
         /// <returns>Task that must be awaited.</returns>
+        [Obsolete("Please switch to version with the MurderResultFlags argument")]
         ValueTask MurderPlayerAsync(IInnerPlayerControl target);
 
         /// <summary>
         ///     Protect <paramref name="target" /> player.
         /// </summary>
         /// <param name="target">Target player to protect.</param>
-        /// <exception cref="ImpostorProtocolException">Thrown when target is a guardian angel.</exception>
+        /// <exception cref="ImpostorProtocolException">Thrown when target is dead.</exception>
         /// <returns>Task that must be awaited.</returns>
         ValueTask ProtectPlayerAsync(IInnerPlayerControl target);
+
+        /// <summary>
+        ///     Protect <paramref name="target" /> player.
+        /// </summary>
+        /// <param name="target">Target player to protect.</param>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask ForceProtectPlayerAsync(IInnerPlayerControl target);
+
+        /// <summary>
+        ///     Exile the current player. This doesn't produce a body to be reported.
+        ///     Visible to all players.
+        /// </summary>
+        /// <exception cref="ImpostorProtocolException">Thrown if player to be exiled is already dead.</exception>
+        /// <returns>Task that must be awaited.</returns>
+        ValueTask ExileAsync();
 
         /// <summary>
         ///     Exile the current player. This doesn't produce a body to be reported.
         ///     Visible to all players.
         /// </summary>
         /// <returns>Task that must be awaited.</returns>
-        ValueTask ExileAsync();
+        ValueTask ForceExileAsync();
     }
 }


### PR DESCRIPTION
### Description

Force(.*)Async will perform the same function as \1Async but without throwing exceptions. The old API is maintained for backwards compatibility reasons.

Murder checks are now shared with the main function that handles CheckMurder, as ProtectPlayerAsync and ExileAsync aren't used in the code I didn't make a similar change there. Checks were also synced between both methods
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #671
