### PR TITLE
Make game ended events cancellable

### DIFF
--- a/src/Impostor.Server/Events/Game/GameEndedEvent.cs
+++ b/src/Impostor.Server/Events/Game/GameEndedEvent.cs
@@ -15,5 +15,7 @@ namespace Impostor.Server.Events
         public IGame Game { get; }
 
         public GameOverReason GameOverReason { get; }
+
+        public bool IsCancelled { get; set; }
     }
 }

--- a/src/Impostor.Server/Net/State/Game.Incoming.cs
+++ b/src/Impostor.Server/Net/State/Game.Incoming.cs
@@ -29,6 +29,14 @@ namespace Impostor.Server.Net.State
 
         public async ValueTask HandleEndGame(IMessageReader message, GameOverReason gameOverReason)
         {
+            var @event = new GameEndedEvent(this, gameOverReason);
+            await _eventManager.CallAsync(new GameEndedEvent(this, gameOverReason));
+
+            if (@event.IsCancelled)
+            {
+                return;
+            }
+
             GameState = GameStates.Ended;
 
             // Broadcast end of the game.
@@ -49,8 +57,6 @@ namespace Impostor.Server.Net.State
             {
                 await DespawnPlayerInfoAsync(playerInfo);
             }
-
-            await _eventManager.CallAsync(new GameEndedEvent(this, gameOverReason));
         }
 
         public async ValueTask HandleAlterGame(IMessageReader message, IClientPlayer sender, bool isPublic)


### PR DESCRIPTION
This PR makes it possible to cancel game ended events, effectively allowing the server to control the conditions for the game ending. This pairs nicely with #677 as it can be used to prevent the game from ending after being forcefully started with less than 4 players.