### PR TITLE
Add support for 16.0.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>11</LangVersion>
-    <VersionPrefix>1.10.2</VersionPrefix>
+    <VersionPrefix>1.10.3</VersionPrefix>
     <VersionSuffix>dev</VersionSuffix>
     <EnforceCodeStyleInBuild Condition="$(MSBuildProjectName)!='Hazel'">true</EnforceCodeStyleInBuild>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>

--- a/src/Impostor.Api/Innersloth/GameOptions/GameTags.cs
+++ b/src/Impostor.Api/Innersloth/GameOptions/GameTags.cs
@@ -1,0 +1,14 @@
+namespace Impostor.Api.Innersloth.GameOptions;
+
+// TODO: generate this enum based on game data
+
+/// <summary>
+/// Tag that can be added to indicate the expected skill level of players in this lobby.
+/// </summary>
+public enum GameTags
+{
+    None = 0,
+    Beginner = 1,
+    Intermediate = 2,
+    Expert = 3,
+}

--- a/src/Impostor.Api/Innersloth/GameOptions/HideNSeekGameOptions.cs
+++ b/src/Impostor.Api/Innersloth/GameOptions/HideNSeekGameOptions.cs
@@ -2,7 +2,7 @@ namespace Impostor.Api.Innersloth.GameOptions;
 
 public class HideNSeekGameOptions : IGameOptions
 {
-    public const int LatestVersion = 8;
+    public const int LatestVersion = 9;
 
     public HideNSeekGameOptions(byte version = LatestVersion)
     {
@@ -93,6 +93,11 @@ public class HideNSeekGameOptions : IGameOptions
 
     public float MaxPingTime { get; set; } = 6f;
 
+    /// <summary>
+    ///     Gets or sets the experience level of people in the lobby: Beginner, Intermediate or Expert.
+    /// </summary>
+    public byte Tag { get; set; } = 0;
+
     public static HideNSeekGameOptions Deserialize(IMessageReader reader, byte version)
     {
         var options = new HideNSeekGameOptions(version);
@@ -133,6 +138,11 @@ public class HideNSeekGameOptions : IGameOptions
         MaxPingTime = reader.ReadSingle();
         CrewmateTimeInVent = reader.ReadSingle();
 
+        if (Version >= 9)
+        {
+            Tag = reader.ReadByte();
+        }
+
         if (Version > LatestVersion)
         {
             IGameOptions.ThrowUnknownVersion<HideNSeekGameOptions>(Version);
@@ -171,6 +181,11 @@ public class HideNSeekGameOptions : IGameOptions
         writer.Write(SeekerPlayerId);
         writer.Write(MaxPingTime);
         writer.Write(CrewmateTimeInVent);
+
+        if (Version >= 9)
+        {
+            writer.Write((byte)Tag);
+        }
 
         if (Version > LatestVersion)
         {

--- a/src/Impostor.Api/Innersloth/GameOptions/HideNSeekGameOptions.cs
+++ b/src/Impostor.Api/Innersloth/GameOptions/HideNSeekGameOptions.cs
@@ -96,7 +96,7 @@ public class HideNSeekGameOptions : IGameOptions
     /// <summary>
     ///     Gets or sets the experience level of people in the lobby: Beginner, Intermediate or Expert.
     /// </summary>
-    public byte Tag { get; set; } = 0;
+    public GameTags Tag { get; set; } = 0;
 
     public static HideNSeekGameOptions Deserialize(IMessageReader reader, byte version)
     {
@@ -140,7 +140,7 @@ public class HideNSeekGameOptions : IGameOptions
 
         if (Version >= 9)
         {
-            Tag = reader.ReadByte();
+            Tag = (GameTags)reader.ReadByte();
         }
 
         if (Version > LatestVersion)

--- a/src/Impostor.Api/Innersloth/GameOptions/NormalGameOptions.cs
+++ b/src/Impostor.Api/Innersloth/GameOptions/NormalGameOptions.cs
@@ -131,7 +131,7 @@ public class NormalGameOptions : IGameOptions
     /// <summary>
     ///     Gets or sets the experience level of people in the lobby: Beginner, Intermediate or Expert.
     /// </summary>
-    public byte Tag { get; set; } = 0;
+    public GameTags Tag { get; set; } = 0;
 
     public RoleOptionsCollection RoleOptions { get; set; }
 
@@ -180,7 +180,7 @@ public class NormalGameOptions : IGameOptions
 
         if (Version >= 9)
         {
-            Tag = reader.ReadByte();
+            Tag = (GameTags)reader.ReadByte();
         }
 
         RoleOptions.Deserialize(reader);

--- a/src/Impostor.Api/Innersloth/GameOptions/NormalGameOptions.cs
+++ b/src/Impostor.Api/Innersloth/GameOptions/NormalGameOptions.cs
@@ -4,7 +4,7 @@ namespace Impostor.Api.Innersloth.GameOptions;
 
 public class NormalGameOptions : IGameOptions
 {
-    public const int LatestVersion = 8;
+    public const int LatestVersion = 9;
 
     public NormalGameOptions(byte version = LatestVersion)
     {
@@ -128,6 +128,11 @@ public class NormalGameOptions : IGameOptions
     /// </summary>
     public TaskBarUpdate TaskBarUpdate { get; set; } = TaskBarUpdate.Always;
 
+    /// <summary>
+    ///     Gets or sets the experience level of people in the lobby: Beginner, Intermediate or Expert.
+    /// </summary>
+    public byte Tag { get; set; } = 0;
+
     public RoleOptionsCollection RoleOptions { get; set; }
 
     public static NormalGameOptions Deserialize(IMessageReader reader, byte version)
@@ -173,6 +178,11 @@ public class NormalGameOptions : IGameOptions
         AnonymousVotes = reader.ReadBoolean();
         TaskBarUpdate = (TaskBarUpdate)reader.ReadByte();
 
+        if (Version >= 9)
+        {
+            Tag = reader.ReadByte();
+        }
+
         RoleOptions.Deserialize(reader);
 
         if (Version > LatestVersion)
@@ -216,6 +226,11 @@ public class NormalGameOptions : IGameOptions
         writer.Write(VisualTasks);
         writer.Write(AnonymousVotes);
         writer.Write((byte)TaskBarUpdate);
+
+        if (Version >= 9)
+        {
+            writer.Write((byte)Tag);
+        }
 
         RoleOptions.Serialize(writer);
 

--- a/src/Impostor.Server/Extensions/IGameOptionsExtensions.cs
+++ b/src/Impostor.Server/Extensions/IGameOptionsExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using Impostor.Api.Innersloth.GameOptions;
+using Impostor.Hazel;
+
+namespace Impostor.Server.Extensions;
+
+public static class IGameOptionsExtensions
+{
+    public static byte[] ToBytes(this IGameOptions gameOptions)
+    {
+        using var writer = MessageWriter.Get(MessageType.Unreliable);
+        writer.Write(gameOptions.Version);
+        writer.StartMessage(0);
+        writer.Write((byte)gameOptions.GameMode);
+        gameOptions.Serialize(writer);
+        writer.EndMessage();
+        return writer.ToByteArray(false);
+    }
+
+    public static string ToBase64String(this IGameOptions gameOptions)
+    {
+        return Convert.ToBase64String(gameOptions.ToBytes());
+    }
+}

--- a/src/Impostor.Server/Http/GamesController.cs
+++ b/src/Impostor.Server/Http/GamesController.cs
@@ -9,6 +9,7 @@ using Impostor.Api.Config;
 using Impostor.Api.Games;
 using Impostor.Api.Games.Managers;
 using Impostor.Api.Innersloth;
+using Impostor.Server.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -308,9 +309,7 @@ public sealed class GamesController : ControllerBase
                 NumImpostors = game.Options.NumImpostors,
                 MapId = game.Options.Map,
                 Language = game.Options.Keywords,
-
-                // TODO don't hardcode
-                Options = "CXQAAAEAAA8AAQAAAgAAwD8AAEA/AAAAQAAAoEECAgQCAAAAAgEtAAAALQAAAAAPAAABAQAHBQABZAMAAAAKHgIAAWQCAAAKDwQAAkYDAAAjDwADAAFkAgAADw8IAAJkAgAACgEJAAFkAgAACh4KAAFkAwAADxQB",
+                Options = game.Options.ToBase64String(),
             };
         }
     }

--- a/src/Impostor.Server/Http/GamesController.cs
+++ b/src/Impostor.Server/Http/GamesController.cs
@@ -113,6 +113,23 @@ public sealed class GamesController : ControllerBase
         return Ok(new FindGameByCodeResponse(GameListingV2.From(game)));
     }
 
+    [HttpGet("filtered")]
+    public IActionResult ShowFilteredLobbies()
+    {
+        // TODO: implement this stub
+        var response = new
+        {
+            games = Array.Empty<GameListingV2>(),
+            metadata = new
+            {
+                allGamesCount = _gameManager.Games.Count(),
+                matchingGamesCount = 0,
+            },
+        };
+
+        return Ok(response);
+    }
+
     private static uint ConvertAddressToNumber(IPAddress address)
     {
 #pragma warning disable CS0618 // Among Us only supports IPv4

--- a/src/Impostor.Server/Http/GamesController.cs
+++ b/src/Impostor.Server/Http/GamesController.cs
@@ -51,6 +51,7 @@ public sealed class GamesController : ControllerBase
     [HttpGet]
     public IActionResult Index(int mapId, GameKeywords lang, int numImpostors, [FromHeader] AuthenticationHeaderValue authorization)
     {
+        // NOTE: this method is no longer used by Among Us 16.0.0 and is only kept for backwards compatibility
         if (authorization.Scheme != "Bearer" || authorization.Parameter == null)
         {
             return BadRequest();
@@ -76,6 +77,7 @@ public sealed class GamesController : ControllerBase
     [HttpPost]
     public IActionResult Post(int gameId)
     {
+        // NOTE: this method is no longer used by Among Us 16.0.0 and is only kept for backwards compatibility
         var code = new GameCode(gameId);
         var game = _gameManager.Find(code);
 

--- a/src/Impostor.Server/Http/GamesController.cs
+++ b/src/Impostor.Server/Http/GamesController.cs
@@ -110,7 +110,7 @@ public sealed class GamesController : ControllerBase
             return NotFound(new FindGameByCodeResponse(new MatchmakerError(DisconnectReason.GameNotFound)));
         }
 
-        return Ok(new FindGameByCodeResponse(GameListingV2.From(game)));
+        return Ok(new FindGameByCodeResponse(GameListing.From(game)));
     }
 
     [HttpGet("filtered")]
@@ -119,7 +119,7 @@ public sealed class GamesController : ControllerBase
         // TODO: implement this stub
         var response = new
         {
-            games = Array.Empty<GameListingV2>(),
+            games = Array.Empty<GameListing>(),
             metadata = new
             {
                 allGamesCount = _gameManager.Games.Count(),
@@ -184,82 +184,22 @@ public sealed class GamesController : ControllerBase
         public required DisconnectReason Reason { get; init; }
     }
 
-    private class GameListing
-    {
-        [JsonPropertyName("IP")]
-        public required uint Ip { get; init; }
-
-        [JsonPropertyName("Port")]
-        public required ushort Port { get; init; }
-
-        [JsonPropertyName("GameId")]
-        public required int GameId { get; init; }
-
-        [JsonPropertyName("PlayerCount")]
-        public required int PlayerCount { get; init; }
-
-        [JsonPropertyName("HostName")]
-        public required string HostName { get; init; }
-
-        [JsonPropertyName("HostPlatformName")]
-        public required string HostPlatformName { get; init; }
-
-        [JsonPropertyName("Platform")]
-        public required Platforms Platform { get; init; }
-
-        [JsonPropertyName("Age")]
-        public required int Age { get; init; }
-
-        [JsonPropertyName("MaxPlayers")]
-        public required int MaxPlayers { get; init; }
-
-        [JsonPropertyName("NumImpostors")]
-        public required int NumImpostors { get; init; }
-
-        [JsonPropertyName("MapId")]
-        public required MapTypes MapId { get; init; }
-
-        [JsonPropertyName("Language")]
-        public required GameKeywords Language { get; init; }
-
-        public static GameListing From(IGame game)
-        {
-            var platform = game.Host?.Client.PlatformSpecificData;
-
-            return new GameListing
-            {
-                Ip = ConvertAddressToNumber(game.PublicIp.Address),
-                Port = (ushort)game.PublicIp.Port,
-                GameId = game.Code,
-                PlayerCount = game.PlayerCount,
-                HostName = game.DisplayName ?? game.Host?.Client.Name ?? "Unknown host",
-                HostPlatformName = platform?.PlatformName ?? string.Empty,
-                Platform = platform?.Platform ?? Platforms.Unknown,
-                Age = 0,
-                MaxPlayers = game.Options.MaxPlayers,
-                NumImpostors = game.Options.NumImpostors,
-                MapId = game.Options.Map,
-                Language = game.Options.Keywords,
-            };
-        }
-    }
-
     private class FindGameByCodeResponse
     {
         [SetsRequiredMembers]
         public FindGameByCodeResponse(MatchmakerError error) => (Errors, Game) = (new[] { error }, null);
 
         [SetsRequiredMembers]
-        public FindGameByCodeResponse(GameListingV2 game) => (Errors, Game) = (null, game);
+        public FindGameByCodeResponse(GameListing game) => (Errors, Game) = (null, game);
 
         [JsonPropertyName("Errors")]
         public required MatchmakerError[]? Errors { get; init; }
 
         [JsonPropertyName("Game")]
-        public required GameListingV2? Game { get; init; }
+        public required GameListing? Game { get; init; }
     }
 
-    private class GameListingV2
+    private class GameListing
     {
         [JsonPropertyName("IP")]
         public required uint Ip { get; init; }
@@ -306,11 +246,11 @@ public sealed class GamesController : ControllerBase
         [JsonPropertyName("Options")]
         public required string Options { get; init; }
 
-        public static GameListingV2 From(IGame game)
+        public static GameListing From(IGame game)
         {
             var platform = game.Host?.Client.PlatformSpecificData;
 
-            return new GameListingV2
+            return new GameListing
             {
                 Ip = ConvertAddressToNumber(game.PublicIp.Address),
                 Port = (ushort)game.PublicIp.Port,

--- a/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
+++ b/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
@@ -21,6 +21,7 @@ internal class CompatibilityManager : ICompatibilityManager
             new GameVersion(2024, 4, 1), // 2024.8.13
             new GameVersion(2024, 4, 2), // 2024.9.4
             new GameVersion(2024, 8, 10), // 2024.10.29
+            new GameVersion(2024, 8, 11), // 16.0.0 (2025-03-25)
         },
     };
 

--- a/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
+++ b/src/Impostor.Server/Net/Manager/CompatibilityManager.cs
@@ -21,6 +21,9 @@ internal class CompatibilityManager : ICompatibilityManager
             new GameVersion(2024, 4, 1), // 2024.8.13
             new GameVersion(2024, 4, 2), // 2024.9.4
             new GameVersion(2024, 8, 10), // 2024.10.29
+        },
+        new[]
+        {
             new GameVersion(2024, 8, 11), // 16.0.0 (2025-03-25)
         },
     };


### PR DESCRIPTION
### Description

This PR adds support for 16.0.0. Most of the changes are in the HTTP side this time, so support for 2024.10.29 was kept

Support is not complete: this version does not list public lobbies right now: the new filtering logic is quite complex so we haven't finished implementing it yet. It'll follow be implemented in a followup PR.
<!-- 

If your pull request closes any issues, add them below with the `closes` keyword before them 

Example: closes #101

See the following article for more information: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

-->

### Closes issues

- closes #682
