### PR TITLE
Don't clear RoleOptions on update

### DIFF
--- a/src/Impostor.Api/Innersloth/GameOptions/RoleOptions/RoleOptionsCollection.cs
+++ b/src/Impostor.Api/Innersloth/GameOptions/RoleOptions/RoleOptionsCollection.cs
@@ -16,8 +16,6 @@ public class RoleOptionsCollection
 
     public void Deserialize(IMessageReader reader)
     {
-        Roles.Clear();
-
         var count = reader.ReadPackedInt32();
         Roles.EnsureCapacity(count);
         for (var i = 0; i < count; i++)
@@ -37,7 +35,7 @@ public class RoleOptionsCollection
                 _ => throw new ArgumentOutOfRangeException(nameof(roleType), roleType, null),
             };
 
-            Roles.Add(roleType, new RoleData(roleType, roleOptions, roleRate));
+            Roles[roleType] = new RoleData(roleType, roleOptions, roleRate);
         }
     }
 


### PR DESCRIPTION
### Description

Among Us always adds a constant amount of roles to this dict, so it doesn't make sense to clear this dictionary every time.

Furthermore, previously it was possible to trigger a ConcurrentModificationException when running Deserialize in parallel with Serialize. This should no longer happen, as new keys are no longer added.
