### PR TITLE
Update docs to add that HTTPS is now mandatory

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -8,6 +8,14 @@ The Impostor project is a reverse engineered and open source server for the game
 
 Yes, Impostor can be used with both the Android and iOS versions of the game. You can add a custom server via a link, you can do this using the [site](https://impostor.github.io/Impostor)
 
+## Can this be used with the console version of the game?
+
+Sadly not, as these don't allow adding custom servers.
+
+## Can this be used with Among Us 3D/VR?
+
+No, it's an entirely different game with a completely different network stack. So we'd need to develop another server completely from scratch. We're currently not interested in doing this.
+
 ## How can I get started?
 
 See [Setting up your Server](Running-the-server.md) for more information on running the server and [Client Setup](https://impostor.github.io/Impostor/) for helping your friends join in!

--- a/docs/Http-server.md
+++ b/docs/Http-server.md
@@ -1,19 +1,13 @@
 # HTTP Server
 
-Since Impostor 1.9.0 a HTTP service is included for matchmaking. Recent versions of Among Us require this service in order to connect correctly and not kick players after a round.
+Since Impostor 1.9.0 a HTTP service is included for matchmaking, which is required for clients to connect to the Impostor server.
 
-Depending on whether you want to support mobile players, you can set up the HTTP server in one of two ways:
-
-- Directly expose the HTTP server. Simpler, but only works if you don't want to support mobile players.
-- Use a reverse proxy to expose the HTTP server. More complex, but allows mobile players to connect.
-
-## Directly expose the HTTP server.
-
-In config.json, set "ListenIp" to "0.0.0.0" in the "HttpServer" section. If you don't have this section, look in the example [config.json](https://github.com/Impostor/Impostor/blob/master/src/Impostor.Server/config.json)
+Starting from Among Us 16.0.5, you need to set up HTTPS for players to connect to your server.
+Unfortunately Impostor doesn't handle SSL certificates, so you need to set up a reverse proxy.
 
 ## Use a reverse proxy
 
-A reverse proxy allows you to forward HTTP requests from users to multiple services. If you already have one, you should configure it to add Impostor. This page contains an Nginx configuration you can use for reference.
+A reverse proxy allows you to forward HTTP requests from users to multiple services. If you already have one, you should configure it to add Impostor. 
 
 If you have never set up a reverse proxy before, we recommend you to set up [Caddy](https://caddyserver.com/). It is easy to set up and comes with support for requesting SSL certificates out of the box.
 
@@ -65,3 +59,24 @@ server {
 ```
 
 </details>
+
+## Stop exposing Impostor's HTTP server to the internet directly
+
+To only allow connections to Impostor's HTTP servers via the reverse proxy, we recommend to set the ListenIp of the HTTP server to 127.0.0.1:
+
+```json
+{
+ // NOTE: merge this snippet into the rest of your configuration
+ "HttpServer": {
+   "ListenIp": "127.0.0.1"
+ }
+}
+```
+
+Or if you're configuring Impostor with environment variables:
+
+```sh
+IMPOSTOR_HttpServer__ListenIp=127.0.0.1
+```
+
+For more information on server configuration, see [Server-configuration.md](Server Configuration).

--- a/docs/Running-the-server.md
+++ b/docs/Running-the-server.md
@@ -10,7 +10,9 @@ To connect to the server, you need to configure and install a region file on htt
 
 Among Us connects to the server using two network services: the (TCP) HTTP service points Among Us to the UDP service, then the UDP service hosts the actual game traffic. Because of this, Impostor uses port 22023 using **both** the TCP and UDP protocols.
 
-As the phone version of Among Us requires this HTTP connection to be secure, we recommend using a HTTP reverse proxy to terminate SSL on the HTTP service. Setup instructions for this are in the [Http Server documentation](Http-server.md).
+To connect to your Among Us version from another PC, you need to set up a HTTP reverse proxy to support HTTPS. If you're just running a version of Impostor for testing Setup instructions for this are in the [Http Server documentation](Http-server.md).
+
+If you want to test if your Among Us HTTP server is working, open `http://localhost:22023` (assuming you're using the default settings, change the IP and port respectively) in a browser
 
 Depending on your host you may also need to port forward Impostor to the internet or pass Impostor traffic by your firewall. Port 22023 UDP needs to be accessible for everyone that wants to play on the server, then you also need to portforward your HTTP reverse proxy or port 22023 TCP if you don't use a reverse proxy. As port forwarding changes per host or router configuration, port forwarding is not covered by this guide.
 
@@ -21,8 +23,9 @@ Depending on your host you may also need to port forward Impostor to the interne
 3. Extract the zip.
 4. Modify `config.json` to your liking. Documentation can be found [here](Server-configuration.md). You need to at least change `PublicIp` to the address people will connect to your server to.
 5. Run `Impostor.Server` (Linux/macOS) or `Impostor.Server.exe` (Windows)
-6. (OPTIONAL - Linux) Configure a systemd definition file and enable the service to start on boot, see [systemd configuration](Server-configuration.md#systemd)
-7. (OPTIONAL) Set up a reverse proxy to support HTTPS, so mobile phones can connect, see [reverse proxy configuration](Http-server.md)
+6. Set up a reverse proxy to support HTTPS, so you can connect to your server from another device. See [reverse proxy configuration](Http-server.md)
+7. (OPTIONAL - Linux) Configure a systemd definition file and enable the service to start on boot, see [systemd configuration](Server-configuration.md#systemd)
+
 
 ## Using Docker
 
@@ -34,7 +37,7 @@ Docker is a program that allows you to run programs like Impostor in a container
 After installing Docker, you can just start a Docker container with `docker run`:
 
 ```
-docker run -p 22023:22023/tcp -p 22023:22023/udp -e IMPOSTOR_Server__PublicIp=your.public.ip.here aeonlucid/impostor:nightly
+docker run -p 127.0.0.1:22023:22023/tcp -p 22023:22023/udp -e IMPOSTOR_Server__PublicIp=your.public.ip.here aeonlucid/impostor:nightly
 ```
 
 Please replace `your.public.ip.here` with the public IP address of your server. This is the address Among Us will try to reach your server at.
@@ -43,7 +46,7 @@ To configure the docker container, either use environment variables or mount con
 
 ## Using Docker Compose
 
-Docker Compose allows you to start a Docker container using a prefined configuration. This is an example configuration you can continue on:
+Docker Compose allows you to start a Docker container using a predefined configuration. This is an example configuration you can continue on:
 
 ```
 version: '3.4'
@@ -53,12 +56,12 @@ services:
     image: aeonlucid/impostor:nightly
     container_name: impostor
     ports:
-      - 22023:22023/tcp # Add "127.0.0.1:" if you're using a reverse proxy to terminate HTTPS
+      - 127.0.0.1:22023:22023/tcp # Set up your own reverse proxy to terminate HTTPS
       - 22023:22023/udp
-    environment: # Either configure Impostor using environment variables or mount a copy of config.json
+    environment: # Either configure Impostor using environment variables or mount config.json in your container
       - IMPOSTOR_Server__PublicIp=your.public.ip.here
     volumes:
-      - /path/to/local/config.json:/app/config.json # For easy editing of the config
+      - /path/to/local/config.json:/app/config.json # Mount config.json
       - /path/to/local/plugins:/app/plugins         # Only needed if using plugins
-      - /path/to/local/libraries:/app/libraries     # Only needed if using external libraries
+      - /path/to/local/libraries:/app/libraries     # Only needed if using external libraries (some plugins may need this)
 ```

--- a/src/Impostor.Server/Net/MatchmakerService.cs
+++ b/src/Impostor.Server/Net/MatchmakerService.cs
@@ -41,6 +41,7 @@ namespace Impostor.Server.Net
                 _serverConfig.ResolvePublicIp(),
                 _serverConfig.PublicPort);
 
+            var runningOutsideContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == null;
             if (_serverConfig.PublicIp == "127.0.0.1")
             {
                 // NOTE: If this warning annoys you, set your PublicIp to "localhost"
@@ -48,11 +49,9 @@ namespace Impostor.Server.Net
                 _logger.LogError("To allow people on other devices to connect to your server, change this value to your Public IP address");
                 _logger.LogError("For more info on how to do this see https://github.com/Impostor/Impostor/blob/master/docs/Server-configuration.md");
             }
-
-            var runningOutsideContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == null;
-            if (_httpServerConfig.ListenIp == "0.0.0.0" && runningOutsideContainer)
+            else if (_httpServerConfig.ListenIp == "0.0.0.0" && runningOutsideContainer)
             {
-                _logger.LogWarning("Your HTTP server is exposed to the public internet, we recommend setting up a reverse proxy and enabling HTTPS");
+                _logger.LogWarning("Since Among Us 16.0.5 it is required to support HTTPS for players to connect, we recommend setting up a reverse proxy:");
                 _logger.LogWarning("See https://github.com/Impostor/Impostor/blob/master/docs/Http-server.md for instructions");
             }
         }


### PR DESCRIPTION
### Description

In another usability blow to the setup process, Impostor now requires an reverse proxy for HTTPS since Among Us 16.0.5.

Will merge in 20 hours or so