### PR TITLE
Fix race condition in SyncServerObjectsAsync

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -468,7 +468,7 @@ namespace Impostor.Server.Net.State
 
         private async ValueTask SyncServerObjectsAsync(ClientPlayer sender)
         {
-            foreach (var obj in _allObjectsFast.Values)
+            foreach (var obj in _allObjectsFast.Values.ToList())
             {
                 if (obj.OwnerId == ServerOwned)
                 {

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -468,7 +468,7 @@ namespace Impostor.Server.Net.State
 
         private async ValueTask SyncServerObjectsAsync(ClientPlayer sender)
         {
-            foreach (var obj in _allObjectsFast.Values.ToList())
+            foreach (var obj in _allObjectsFast.Values)
             {
                 if (obj.OwnerId == ServerOwned)
                 {


### PR DESCRIPTION
### Description

Fixes an error when 2 players join at the same time by using ToList(), which makes it so the the loop iterates an independent list that can't be affected by 2 players touching the same dictionary during the awaits.

If this produces unforeseen errors I can refine my change