### PR TITLE
Fix race condition in SyncServerObjectsAsync

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -468,7 +468,7 @@ namespace Impostor.Server.Net.State
 
         private async ValueTask SyncServerObjectsAsync(ClientPlayer sender)
         {
-            foreach (var obj in _allObjectsFast.Values)
+            foreach (var obj in _allObjectsFast.Values.ToList())
             {
                 if (obj.OwnerId == ServerOwned)
                 {


### PR DESCRIPTION
I'll attach my old pull request description here:

> ### Description
> Fixes an error when 2 players join at the same time by using ToList(), which makes it so the the loop iterates an independent list that can't be affected by 2 players touching the same dictionary during the awaits.
> 
> If this produces unforeseen errors I can refine my change.
> 
> I also fixed the commit message to be more descriptive than [my last pull request](https://github.com/Impostor/Impostor/pull/719)
> 
> I also made the title of this pull request better than I did for [this one](https://github.com/Impostor/Impostor/pull/720)

After reading the feedback on my most recent pull, I realized the reason you wanted me to give a detailed commit message was probably to keep the commit history clean, NOT just so that it would show as the most recent edit to the file.

However, my first patch, I had completely forgot to create a new branch before I did my first messy commit, so I ended up deleting the entire old repo. This commit comes from my new one with a much cleaner commit.

This pull should hopefully be the last of this saga. Sorry NikoCat 😬