### PR TITLE
Fix race conditions in Game.Data

### DIFF
--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -60,9 +61,7 @@ namespace Impostor.Server.Net.State
 
         private static readonly Dictionary<Type, uint> SpawnableObjectIds = SpawnableObjects.ToDictionary((i) => i.Value, (i) => i.Key);
 
-        private readonly List<InnerNetObject> _allObjects = new List<InnerNetObject>();
-
-        private readonly Dictionary<uint, InnerNetObject> _allObjectsFast = new Dictionary<uint, InnerNetObject>();
+        private readonly ConcurrentDictionary<uint, InnerNetObject> _allObjectsFast = new ConcurrentDictionary<uint, InnerNetObject>();
 
         private uint _nextNetId = MinServerNetId;
 
@@ -533,25 +532,12 @@ namespace Impostor.Server.Net.State
 
         private bool AddNetObject(InnerNetObject obj)
         {
-            if (_allObjectsFast.ContainsKey(obj.NetId))
-            {
-                return false;
-            }
-
-            _allObjects.Add(obj);
-            _allObjectsFast.Add(obj.NetId, obj);
-            return true;
+            return _allObjectsFast.TryAdd(obj.NetId, obj);
         }
 
         private void RemoveNetObject(InnerNetObject obj)
         {
-            var index = _allObjects.IndexOf(obj);
-            if (index > -1)
-            {
-                _allObjects.RemoveAt(index);
-            }
-
-            _allObjectsFast.Remove(obj.NetId);
+            _allObjectsFast.TryRemove(obj.NetId, out _);
         }
     }
 }

--- a/src/Impostor.Server/Net/State/Game.Data.cs
+++ b/src/Impostor.Server/Net/State/Game.Data.cs
@@ -61,14 +61,14 @@ namespace Impostor.Server.Net.State
 
         private static readonly Dictionary<Type, uint> SpawnableObjectIds = SpawnableObjects.ToDictionary((i) => i.Value, (i) => i.Key);
 
-        private readonly ConcurrentDictionary<uint, InnerNetObject> _allObjectsFast = new ConcurrentDictionary<uint, InnerNetObject>();
+        private readonly ConcurrentDictionary<uint, InnerNetObject> _allObjects = new ConcurrentDictionary<uint, InnerNetObject>();
 
         private uint _nextNetId = MinServerNetId;
 
         public T? FindObjectByNetId<T>(uint netId)
             where T : IInnerNetObject
         {
-            if (_allObjectsFast.TryGetValue(netId, out var obj))
+            if (_allObjects.TryGetValue(netId, out var obj))
             {
                 return (T)(IInnerNetObject)obj;
             }
@@ -103,7 +103,7 @@ namespace Impostor.Server.Net.State
                     case GameDataTag.DataFlag:
                     {
                         var netId = reader.ReadPackedUInt32();
-                        if (_allObjectsFast.TryGetValue(netId, out var obj))
+                        if (_allObjects.TryGetValue(netId, out var obj))
                         {
                             await obj.DeserializeAsync(sender, target, reader, false);
                         }
@@ -118,7 +118,7 @@ namespace Impostor.Server.Net.State
                     case GameDataTag.RpcFlag:
                     {
                         var netId = reader.ReadPackedUInt32();
-                        if (_allObjectsFast.TryGetValue(netId, out var obj))
+                        if (_allObjects.TryGetValue(netId, out var obj))
                         {
                             if (!await obj.HandleRpcAsync(sender, target, (RpcCalls)reader.ReadByte(), reader))
                             {
@@ -213,7 +213,7 @@ namespace Impostor.Server.Net.State
                     case GameDataTag.DespawnFlag:
                     {
                         var netId = reader.ReadPackedUInt32();
-                        if (_allObjectsFast.TryGetValue(netId, out var obj))
+                        if (_allObjects.TryGetValue(netId, out var obj))
                         {
                             if (sender.Client.Id != obj.OwnerId && !sender.IsHost)
                             {
@@ -467,7 +467,7 @@ namespace Impostor.Server.Net.State
 
         private async ValueTask SyncServerObjectsAsync(ClientPlayer sender)
         {
-            foreach (var obj in _allObjectsFast.Values)
+            foreach (var obj in _allObjects.Values)
             {
                 if (obj.OwnerId == ServerOwned)
                 {
@@ -532,12 +532,12 @@ namespace Impostor.Server.Net.State
 
         private bool AddNetObject(InnerNetObject obj)
         {
-            return _allObjectsFast.TryAdd(obj.NetId, obj);
+            return _allObjects.TryAdd(obj.NetId, obj);
         }
 
         private void RemoveNetObject(InnerNetObject obj)
         {
-            _allObjectsFast.TryRemove(obj.NetId, out _);
+            _allObjects.TryRemove(obj.NetId, out _);
         }
     }
 }


### PR DESCRIPTION
### Description

The variable _allObjectsFast is accessed from multiple threads, which causes issues on busy servers.

After trying #722 in production, I found that while the original issue was solved, NullReferenceExceptions would start popping up. Therefore I went a step further and changed to a concurrent dictionary.

This seems to not cause exceptions in production, without significant extra load.

### Closes issues

- closes #722 
