### PR TITLE
Add length check for voting complete

### DIFF
--- a/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
+++ b/src/Impostor.Server/Net/Inner/Objects/InnerMeetingHud.cs
@@ -132,6 +132,18 @@ namespace Impostor.Server.Net.Inner.Objects
                         return false;
                     }
 
+                    var position = reader.Position;
+                    var statesLength = reader.ReadPackedInt32();
+                    reader.Seek(position);
+
+                    if (statesLength < 0 || statesLength > Game.Options.MaxPlayers)
+                    {
+                        if (await sender.Client.ReportCheatAsync(call, CheatCategory.ProtocolExtension, $"Client sent {nameof(RpcCalls.VotingComplete)} with invalid voter state length {statesLength}, max allowed is {Game.Options.MaxPlayers}"))
+                        {
+                            return false;
+                        }
+                    }
+
                     Rpc23VotingComplete.Deserialize(reader, out var states, out var playerId, out var tie);
                     foreach (var messageReader in states)
                     {


### PR DESCRIPTION
Saw the cheat here:
https://github.com/MrDiamond64/Hydra/commit/654ef982f2be176d79aa87e67c7543db39779a65#diff-114a4023cd7709d091a2dda6e6601d00fc30d4ffe80b8ca9374b62bbbded99d6R141

Thanks to HydraMenu for revealing this exploit.

Basically, if a client serializes an extremely large value for the `voterStates` length in the `RPC Voting Complete` packet, the game will pre-allocate a massive amount of memory for the array. Repeated abuse of this behavior can lead to excessive memory allocation and eventual memory exhaustion.

To prevent this, we validate the value against `GameOptions.MaxPlayers`. This avoids false positives while effectively blocking the exploit.
